### PR TITLE
Lift all 50 skills to 9–10 vs writing-great-skills rubric

### DIFF
--- a/37signals-way/SKILL.md
+++ b/37signals-way/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: 37signals-way
-description: 'Build lean, opinionated products using the 37signals philosophy from "Getting Real", "Rework", and "Shape Up". Use when the user mentions "Getting Real", "Rework", "Shape Up", "37signals", "Basecamp method", "six-week cycles", "fixed time variable scope", "appetite vs estimates", "betting table", "breadboarding", "fat marker sketch", "build less", "underdo the competition", "opinionated software", "we have too many meetings", "the project keeps growing", "how do we ship faster", or "stop overbuilding". Also trigger when cutting scope to ship sooner, fighting feature creep, running a small team, avoiding long-term roadmaps, or killing unnecessary meetings. Covers shaping, betting, building, and the art of saying no. For MVP validation, see lean-startup. For design sprints, see design-sprint.'
+description: 'Build lean, opinionated products using the 37signals philosophy from "Getting Real", "Rework", and "Shape Up". Use when the user mentions "Getting Real", "Rework", "Shape Up", "37signals", "Basecamp method", "six-week cycles", "fixed time variable scope", "appetite vs estimates", "betting table", "breadboarding", "fat marker sketch", "build less", "underdo the competition", "opinionated software", "we have too many meetings", "how do we ship faster", or "stop overbuilding". Also trigger when cutting scope to ship sooner, running a small team, or avoiding long-term roadmaps. Covers shaping, betting, building, and the art of saying no. For MVP validation, see lean-startup. For design sprints, see design-sprint.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.2.0"
+  version: "1.3.0"
 ---
 
 # The 37signals Product Development Framework
@@ -46,9 +46,7 @@ A system for building profitable software without bloat, bureaucracy, or burnout
 | **MVP scoping** | Cut until it hurts, then cut more | Drop user accounts for v1; use email magic links |
 | **Competitive strategy** | Underdo, don't outdo | Competitor has 50 integrations; ship 3 that work flawlessly |
 
-**Ethical boundary:** Cut complexity, not accessibility or safety — "less" means focused, not neglectful.
-
-See: [references/build-less.md](references/build-less.md)
+See [references/build-less.md](references/build-less.md) when deciding what to cut — curation tactics, the constraints-as-feature argument, and worked scope-cut examples.
 
 ### 2. Shaping the Work
 
@@ -73,7 +71,7 @@ See: [references/build-less.md](references/build-less.md)
 
 **Ethical boundary:** Set appetites that reflect the problem's genuine value — never artificially small to pressure teams.
 
-See: [references/shaping-work.md](references/shaping-work.md)
+See [references/shaping-work.md](references/shaping-work.md) when drafting a pitch — the five-element pitch format, a worked breadboard, fat-marker rules, the rabbit-hole pattern table, good/bad no-go examples, and a 6-step shaping procedure.
 
 ### 3. Betting and Cycles
 
@@ -98,7 +96,7 @@ See: [references/shaping-work.md](references/shaping-work.md)
 
 **Ethical boundary:** Apply the circuit breaker honestly — to kill zombies, not politically inconvenient projects; the point is focus, not unsustainable pressure.
 
-See: [references/betting-cycles.md](references/betting-cycles.md)
+See [references/betting-cycles.md](references/betting-cycles.md) when running a betting table or planning a cycle — how the table decides, structuring the six-week/two-week rhythm, applying the circuit breaker, and the case against backlogs.
 
 ### 4. Small Teams and Execution
 
@@ -123,13 +121,13 @@ See: [references/betting-cycles.md](references/betting-cycles.md)
 
 **Ethical boundary:** Autonomy requires genuinely manageable scope — if a team consistently works overtime to hit six weeks, fix the shaping, not the team.
 
-See: [references/small-teams-execution.md](references/small-teams-execution.md)
+See [references/small-teams-execution.md](references/small-teams-execution.md) when a team is mid-build — reading and updating hill charts, slicing scopes, async communication norms, and getting real with working HTML.
 
 ### 5. Opinionated Software and Clear Communication
 
 **Core concept:** Great software makes choices instead of burying users in preferences — every preference is a decision the team could not or would not make. The same honesty applies to copy: say what you mean, skip buzzwords, teach what you know openly.
 
-**Why it works:** Software with 47 settings has no opinion; sensible defaults reduce cognitive load and create cohesion. Clear copy builds trust where marketing-speak erodes it, and teaching openly attracts customers who share your values.
+**Why it works:** Every added preference splits the product into more states to design, test, and support, and pushes a decision onto users who lack the context to make it well; sensible defaults reduce cognitive load and create cohesion. Clear copy builds trust where marketing-speak erodes it, and teaching openly attracts customers who share your values.
 
 **Key insights:**
 - Pick the best default and ship it — revisit only if data shows it fails most users
@@ -148,9 +146,7 @@ See: [references/small-teams-execution.md](references/small-teams-execution.md)
 | **Preferences** | Eliminate; choose defaults | Detect timezone from the browser; ship one good theme |
 | **Marketing** | Honest positioning | "Basecamp is not for everyone. Here's who it's for and who it's not for." |
 
-**Ethical boundary:** Opinionated means having a point of view, not ignoring feedback — listen carefully, then curate thoughtfully.
-
-See: [references/opinionated-software.md](references/opinionated-software.md), [references/ux-ui-copy.md](references/ux-ui-copy.md)
+See [references/opinionated-software.md](references/opinionated-software.md) when responding to feature requests or removing settings, and [references/ux-ui-copy.md](references/ux-ui-copy.md) when writing interface copy, empty states, or error messages.
 
 ## Common Mistakes
 
@@ -178,15 +174,7 @@ See: [references/opinionated-software.md](references/opinionated-software.md), [
 | Is there a cool-down after this cycle? | Burnout; no cleanup time | Schedule two unstructured weeks between cycles |
 | Does the software have a clear opinion here? | Decisions deferred to users via preferences | Pick the best default; remove the setting |
 
-## Reference Files
-
-- [references/build-less.md](references/build-less.md) — Underdoing the competition, embracing constraints, curation over accumulation, the art of cutting scope
-- [references/shaping-work.md](references/shaping-work.md) — Breadboarding, fat marker sketches, appetite setting, the pitch format, identifying rabbit holes
-- [references/betting-cycles.md](references/betting-cycles.md) — Six-week cycles, the betting table, the circuit breaker, cool-downs, why backlogs must die
-- [references/small-teams-execution.md](references/small-teams-execution.md) — Three-person teams, hill charts, async communication, getting real with HTML, launch-first thinking
-- [references/opinionated-software.md](references/opinionated-software.md) — Defaults over preferences, clear copywriting, saying no to feature requests, teaching openly
-- [references/ux-ui-copy.md](references/ux-ui-copy.md) — Browser-first design, visual hierarchy, clear copy rules, empty states, error messages, anti-patterns
-- [references/case-studies.md](references/case-studies.md) — Three scenarios: adopting Shape Up, resisting feature creep, replacing status meetings with hill charts
+See [references/case-studies.md](references/case-studies.md) for end-to-end worked scenarios when you want a model to follow — adopting Shape Up, resisting feature creep, and replacing status meetings with hill charts.
 
 ## Further Reading
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Intro paragraph about the framework.
 
 ## Scoring
 
-**Goal: 10/10.** Score with concrete, checkable bands tied to the Quick Diagnostic (e.g. "1 point per satisfied row"; spell out 9-10 / 7-8 / 5-6 / <=3) so the rating is reproducible across runs.
+**Goal: 10/10.** Score with a reproducible rule tied to the Quick Diagnostic that spans the full 0-10 — e.g. `score = round(rows passed / N × 10)` — then spell out the 9-10 / 7-8 / 5-6 / <=3 bands. (Don't write "1 point per row" when there are fewer than 10 rows: the top band becomes unreachable.)
 
 ## Framework Sections
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,28 +59,25 @@ Intro paragraph about the framework.
 
 ## Scoring
 
-**Goal: 10/10.** Rate 0-10 based on adherence to the principles below...
+**Goal: 10/10.** Score with concrete, checkable bands tied to the Quick Diagnostic (e.g. "1 point per satisfied row"; spell out 9-10 / 7-8 / 5-6 / <=3) so the rating is reproducible across runs.
 
 ## Framework Sections
 
 ### 1. First Section
 
 **Core concept:** ...
-**Why it works:** ...
-**Key insights:** (bullet list)
+**Why it works:** ... (only when it states a real mechanism — cut if it just restates the Core concept)
+**Key insights:** (bullet list of non-obvious points only)
 **Product applications:** (table: Context | Application | Example)
 **Copy patterns:** (bullet list with quoted examples)
-**Ethical boundary:** ...
-See: [references/file.md](references/file.md)
+**Ethical boundary:** ... (only when a concrete, behavior-changing constraint — omit platitudes the model already follows)
+See [references/file.md](references/file.md) when <situation> — <what it adds>   (inline when-to-read pointer, at the point of need; no trailing roster)
 
 ## Common Mistakes
 (Table: Mistake | Why It Fails | Fix)
 
 ## Quick Diagnostic
 (Table: Question | If No | Action)
-
-## Reference Files
-(List with descriptions)
 
 ## Further Reading
 (Amazon links with ?tag=wondelai00-20)

--- a/blue-ocean-strategy/SKILL.md
+++ b/blue-ocean-strategy/SKILL.md
@@ -4,7 +4,7 @@ description: 'Create uncontested market space using value innovation instead of 
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # Blue Ocean Strategy Framework
@@ -17,7 +17,7 @@ Strategic framework for creating uncontested market space that makes the competi
 
 ## Scoring
 
-**Goal: 10/10.** Score a strategy by counting how many of the five Quick Diagnostic rows it satisfies (1 point each):
+**Goal: 10/10.** Score a strategy by how many of the five Quick Diagnostic rows it satisfies, mapped to the bands below:
 
 - **9-10** — divergent strategy-canvas curve, eliminates AND creates factors, breaks the value-cost trade-off, converts non-customers, and delivers a 10x utility leap (all 5 rows).
 - **7-8** — value innovation is real but one gate is weak (e.g. strong divergence and cost cuts, but still chasing existing customers rather than non-customers).

--- a/blue-ocean-strategy/SKILL.md
+++ b/blue-ocean-strategy/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: blue-ocean-strategy
-description: 'Create uncontested market space using value innovation instead of competing head-to-head. Use when the user mentions "blue ocean", "red ocean", "strategy canvas", "ERRC framework", "value innovation", "non-customers", "buyer utility map", "uncontested market", "stop competing on price", "everyone is undercutting us", "the market is too crowded", or "how do we stand out". Also trigger when comparing pricing strategies, exploring new market categories, finding underserved or non-customers, or escaping a brutal price war. Covers the Four Actions Framework, buyer utility map, and value-cost trade-offs. For tech adoption strategy, see crossing-the-chasm. For product positioning, see obviously-awesome.'
+description: 'Create uncontested market space using value innovation instead of competing head-to-head. Use when the user mentions "blue ocean", "red ocean", "strategy canvas", "ERRC framework", "value innovation", "non-customers", "buyer utility map", "the market is too crowded", "how do we stand out", or "escape the price war". Also trigger when exploring a new market category, or finding underserved or non-customers. Covers the Four Actions Framework, Six Paths, buyer utility map, and value-cost trade-offs. For real strategy formulation and bad-strategy detection, see good-strategy-bad-strategy. For tech adoption strategy, see crossing-the-chasm. For product positioning, see obviously-awesome.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Blue Ocean Strategy Framework
@@ -17,7 +17,14 @@ Strategic framework for creating uncontested market space that makes the competi
 
 ## Scoring
 
-**Goal: 10/10.** Rate any business strategy or value proposition 0-10 against blue ocean principles: clear value innovation, elimination of unnecessary factors, and creation of new demand. Report the current score and the specific moves needed to reach 10/10; low scores mean competing in a red ocean.
+**Goal: 10/10.** Score a strategy by counting how many of the five Quick Diagnostic rows it satisfies (1 point each):
+
+- **9-10** — divergent strategy-canvas curve, eliminates AND creates factors, breaks the value-cost trade-off, converts non-customers, and delivers a 10x utility leap (all 5 rows).
+- **7-8** — value innovation is real but one gate is weak (e.g. strong divergence and cost cuts, but still chasing existing customers rather than non-customers).
+- **5-6** — differentiation without cost cuts, or cost cuts without a value leap: better than rivals on the same factors, not yet value innovation (2-3 rows).
+- **<=3** — competes on the same factors as rivals with a look-alike canvas curve: a red ocean (0-1 rows).
+
+Report the current score, which diagnostic rows fail, and the specific ERRC/Six-Paths moves needed to reach 10/10.
 
 ## Framework
 
@@ -35,13 +42,11 @@ Strategic framework for creating uncontested market space that makes the competi
 
 **Examples:** Airlines competing on routes, amenities, and price are red ocean; Cirque du Soleil inventing a new entertainment form, Netflix replacing rental with streaming, and Nintendo Wii trading graphics power for accessible motion gaming are blue.
 
-See: [references/blue-ocean-examples.md](references/blue-ocean-examples.md) for detailed case studies.
+See [references/blue-ocean-examples.md](references/blue-ocean-examples.md) when you want a full worked case to model a move on — Cirque du Soleil, Netflix, Yellow Tail, and Nintendo Wii broken down factor by factor.
 
 ### 2. Value Innovation
 
-**Core concept:** The cornerstone of blue ocean strategy — pursue differentiation and low cost simultaneously, creating a leap in value for buyers and the company (Value Innovation = Utility × Price × Cost).
-
-**Why it works:** Eliminating and reducing over-served factors cuts costs at the same time that raising and creating factors lifts buyer value — value rises more than cost, breaking the trade-off competitors assume is fixed.
+**Core concept:** The cornerstone of blue ocean strategy — pursue differentiation and low cost simultaneously, creating a leap in value for buyers and the company. Eliminating and reducing over-served factors cuts cost at the same time raising and creating factors lifts buyer value, so value rises faster than cost and the trade-off competitors assume is fixed breaks.
 
 | Traditional View | Value Innovation View |
 |-----------------|---------------------|
@@ -51,7 +56,7 @@ See: [references/blue-ocean-examples.md](references/blue-ocean-examples.md) for 
 
 **Example — Cirque du Soleil:** eliminated animal shows, star performers, multiple arenas (cost down); reduced thrill and humor; raised venue quality, artistic music and dance; created theme, refined environment, multiple productions. Outcome: priced above circus, costs below theater, a new market.
 
-See: [references/value-innovation.md](references/value-innovation.md) for value innovation frameworks.
+See [references/value-innovation.md](references/value-innovation.md) when testing whether an idea is genuine value innovation — the Utility x Price x Cost formula with all three terms and the test questions for each.
 
 ### 3. Strategy Canvas
 
@@ -73,7 +78,7 @@ See: [references/value-innovation.md](references/value-innovation.md) for value 
 
 **Result:** A different curve = blue ocean.
 
-See: [references/strategy-canvas.md](references/strategy-canvas.md) for templates and examples.
+See [references/strategy-canvas.md](references/strategy-canvas.md) when plotting your own canvas — a blank template and step-by-step build instructions.
 
 ### 4. Four Actions Framework (ERRC Grid)
 
@@ -86,11 +91,9 @@ See: [references/strategy-canvas.md](references/strategy-canvas.md) for template
 | **Raise** | What should go well above industry standard? | Cirque: artistic value; Dyson: suction, design; Apple: UX | Value up; hard to match |
 | **Create** | What has the industry never offered? | Netflix: unlimited streaming, no late fees; Uber: live tracking, cashless payment | New demand; attracts non-customers |
 
-**Net result:** value increases more than cost — value innovation.
-
 **Ethical boundary:** Don't eliminate factors buyers truly value (especially safety or accessibility) — test assumptions before cutting.
 
-See: [references/errc-grid.md](references/errc-grid.md) for ERRC templates and exercises.
+See [references/errc-grid.md](references/errc-grid.md) when running the exercise with a team — a 3.5-hour workshop format, validation checklists, and fresh ERRC matrices for Zoom, IKEA, MinuteClinic, and Khan Academy.
 
 ### 5. Six Paths Framework
 
@@ -105,7 +108,7 @@ See: [references/errc-grid.md](references/errc-grid.md) for ERRC templates and e
 | **5. Functional ↔ emotional appeal** | Flip the industry's basis of appeal | Swatch: watches as fashion; The Body Shop: cosmetics as ethics | Identify current appeal → build the hybrid |
 | **6. Time** | Irreversible trends | iPod/iTunes anticipating digital music; Tesla on EVs | Project the trend's endpoint → build for it today |
 
-See: [references/six-paths.md](references/six-paths.md) for detailed path exercises.
+See [references/six-paths.md](references/six-paths.md) when hunting for opportunities path by path — the prompting questions and a worked example for each of the six.
 
 ### 6. Three Tiers of Non-Customers
 
@@ -119,7 +122,7 @@ See: [references/six-paths.md](references/six-paths.md) for detailed path exerci
 
 **Process:** map all three tiers → find commonalities across tiers → identify what would unlock massive demand → build the offering to convert them.
 
-See: [references/non-customers.md](references/non-customers.md) for non-customer analysis frameworks.
+See [references/non-customers.md](references/non-customers.md) when sizing latent demand — how to map each of the three tiers and find the commonalities that unlock them.
 
 ### 7. Strategic Sequence: Utility → Price → Cost → Adoption
 
@@ -134,7 +137,7 @@ See: [references/non-customers.md](references/non-customers.md) for non-customer
 
 **Ethical boundary:** Win adoption by genuinely addressing stakeholder concerns, not by steamrolling the employees and partners who bear the costs of the shift.
 
-See: [references/sequence.md](references/sequence.md) for sequence templates; [references/implementation.md](references/implementation.md) for execution and organizational alignment.
+See [references/sequence.md](references/sequence.md) when validating an idea gate by gate — the buyer-utility map, strategic-pricing corridor, and target-costing worksheet. See [references/implementation.md](references/implementation.md) when moving from idea to rollout — overcoming the four organizational hurdles and aligning the team behind the shift.
 
 ## Common Mistakes
 
@@ -155,17 +158,6 @@ See: [references/sequence.md](references/sequence.md) for sequence templates; [r
 | Are we breaking the value-cost trade-off? | Traditional competition | Identify over-served factors to cut |
 | Are we converting non-customers? | Fighting for existing share | Map the three tiers of non-customers |
 | Is there a leap in buyer utility? | Incremental improvement | Aim for 10x on key utility levers |
-
-## Reference Files
-
-- [blue-ocean-examples.md](references/blue-ocean-examples.md): Cirque du Soleil, Netflix, Yellow Tail, Nintendo Wii case studies
-- [value-innovation.md](references/value-innovation.md): Value innovation frameworks and formulas
-- [strategy-canvas.md](references/strategy-canvas.md): Templates, examples, how to create
-- [errc-grid.md](references/errc-grid.md): Four Actions Framework exercises and templates
-- [six-paths.md](references/six-paths.md): Detailed exercises for each path
-- [non-customers.md](references/non-customers.md): Three-tier analysis frameworks
-- [sequence.md](references/sequence.md): Utility, price, cost, adoption templates
-- [implementation.md](references/implementation.md): Execution, organizational alignment
 
 ## Further Reading
 

--- a/clean-architecture/SKILL.md
+++ b/clean-architecture/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: clean-architecture
-description: 'Structure software around the Dependency Rule: source code dependencies point inward from frameworks to use cases to entities. Use when the user mentions "architecture layers", "dependency rule", "ports and adapters", "hexagonal architecture", "onion architecture", "screaming architecture", "where should business logic go", "decouple from the database", "swap the framework without a rewrite", "business logic is tangled with the framework", or "keep business rules independent". Also trigger when deciding which layer code belongs in, isolating core logic from infrastructure, defining module boundaries, or debating whether the framework should call your code or the reverse. Covers component principles, boundaries, and SOLID. For code-level quality, see clean-code. For domain modeling, see domain-driven-design.'
+description: 'Structure software around the Dependency Rule: source code dependencies point inward from frameworks to use cases to entities. Use when the user mentions "architecture layers", "dependency rule", "ports and adapters (hexagonal)", "onion architecture", "screaming architecture", "where should business logic go", "decouple from the database", "swap the framework without a rewrite", or "keep business rules independent". Also trigger when deciding which layer code belongs in, isolating core logic from infrastructure, defining module boundaries, or debating whether the framework should call your code or the reverse. Covers component principles, boundaries, and SOLID. For code-level quality, see clean-code. For domain modeling, see domain-driven-design.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Clean Architecture Framework
@@ -17,7 +17,7 @@ A disciplined approach to structuring software so that business rules remain ind
 
 ## Scoring
 
-**Goal: 10/10.** Rate any architecture 0-10 against the principles below. Report the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score one point for each of the seven Quick Diagnostic rows the architecture satisfies (0-7), then map to a 0-10 band: 6-7 satisfied = **9-10** (Dependency Rule holds, business logic is framework- and DB-independent); 4-5 = **6-8** (core is testable but some details leak inward); 2-3 = **3-5** (framework or persistence dictates structure); 0-1 = **0-2** (no boundaries — business rules live in controllers and ORM models). Report the score, the failed diagnostic rows, and the specific inversion needed to fix each.
 
 ### 1. Dependency Rule and Concentric Circles
 
@@ -40,7 +40,7 @@ A disciplined approach to structuring software so that business rules remain ind
 | **Data crossing** | DTOs cross boundaries, not ORM entities | Use Case returns `UserResponse` DTO, not an ActiveRecord model |
 | **Dependency direction** | Import arrows always point inward | Controller imports Use Case; Use Case never imports Controller |
 
-See: [references/dependency-rule.md](references/dependency-rule.md)
+See [references/dependency-rule.md](references/dependency-rule.md) when an inner-circle import points outward and you need the four-circle code walkthrough, the data-crossing rules, and the four-step dependency-inversion procedure to fix it.
 
 ### 2. Entities and Use Cases
 
@@ -64,7 +64,7 @@ See: [references/dependency-rule.md](references/dependency-rule.md)
 | **Single responsibility** | One Use Case per operation | `PlaceOrder`, `CancelOrder`, `RefundOrder` as separate classes |
 | **Interactor** | Implements Input Port, calls Output Port | `PlaceOrderInteractor implements PlaceOrderInput` |
 
-See: [references/entities-use-cases.md](references/entities-use-cases.md)
+See [references/entities-use-cases.md](references/entities-use-cases.md) when designing an Interactor or deciding what belongs in an Entity versus a Use Case — full Enterprise vs. Application Business Rules treatment with request/response model examples.
 
 ### 3. Interface Adapters and Frameworks
 
@@ -87,7 +87,7 @@ See: [references/entities-use-cases.md](references/entities-use-cases.md)
 | **Gateway** | Repository interface implemented per DB | `SqlOrderRepository implements OrderRepository` |
 | **Framework boundary** | Framework calls inward, never the reverse | Express route handler calls Controller; Controller never imports Express |
 
-See: [references/adapters-frameworks.md](references/adapters-frameworks.md)
+See [references/adapters-frameworks.md](references/adapters-frameworks.md) when wiring controllers, presenters, or gateways, or arguing that the database/web is a detail — covers plugin architecture and how to confine a framework to the edges.
 
 ### 4. Component Principles
 
@@ -111,7 +111,7 @@ See: [references/adapters-frameworks.md](references/adapters-frameworks.md)
 | **Breaking cycles** | Apply DIP to invert a dependency edge | Extract an interface into a new component to break the cycle |
 | **Stability metrics** | Instability I = Ce / (Ca + Ce) | Many incoming, no outgoing deps → I near 0 (stable) |
 
-See: [references/component-principles.md](references/component-principles.md)
+See [references/component-principles.md](references/component-principles.md) when grouping classes into deployable components or breaking a dependency cycle — each of REP, CCP, CRP, ADP, SDP, SAP worked through with the instability metric.
 
 ### 5. SOLID Principles
 
@@ -136,7 +136,7 @@ See: [references/component-principles.md](references/component-principles.md)
 | **ISP application** | Split fat interfaces into role interfaces | `Printer`, `Scanner`, `Fax` instead of one `MultiFunctionDevice` |
 | **DIP wiring** | High-level defines interface; low-level implements | `OrderService` depends on `PaymentGateway`, not `StripeClient` |
 
-See: [references/solid-principles.md](references/solid-principles.md)
+See [references/solid-principles.md](references/solid-principles.md) when applying SRP/OCP/LSP/ISP/DIP to a specific class or diagnosing a violation — each principle worked through with code examples and the smell it prevents.
 
 ### 6. Boundaries and Boundary Anatomy
 
@@ -159,7 +159,7 @@ See: [references/solid-principles.md](references/solid-principles.md)
 | **Humble Object** | Separate testable logic from infrastructure | `PresenterLogic` (testable) produces `ViewModel`; `View` (humble) renders it |
 | **Main as plugin** | Composition root assembles the system | `main()` wires all concrete implementations and starts the app |
 
-See: [references/boundaries.md](references/boundaries.md)
+See [references/boundaries.md](references/boundaries.md) when deciding where to draw a boundary, choosing full vs. partial, or applying the Humble Object pattern — also covers services as boundaries, test boundaries, and Main as the ultimate plugin.
 
 ## Common Mistakes
 
@@ -184,15 +184,6 @@ See: [references/boundaries.md](references/boundaries.md)
 | Is the framework confined to the outermost circle? | Framework is your architecture | Wrap framework calls behind interfaces; push to the edges |
 | Is the component graph cycle-free? | Circular dependencies exist | Apply ADP: DIP or new components to break every cycle |
 | Does Main (composition root) wire all dependencies? | Concrete classes instantiated in inner circles | Move construction to Main; use DI or factories |
-
-## Reference Files
-
-- [dependency-rule.md](references/dependency-rule.md): The Dependency Rule explained, concentric circles, data crossing boundaries, keeping the inner circle pure
-- [entities-use-cases.md](references/entities-use-cases.md): Enterprise Business Rules, Application Business Rules, the Interactor pattern, request/response models
-- [adapters-frameworks.md](references/adapters-frameworks.md): Interface adapters, frameworks as details, database as a detail, plugin architecture
-- [component-principles.md](references/component-principles.md): REP, CCP, CRP, ADP, SDP, SAP — component cohesion and coupling
-- [solid-principles.md](references/solid-principles.md): SRP, OCP, LSP, ISP, DIP with code examples and common violations
-- [boundaries.md](references/boundaries.md): Boundary anatomy, Humble Object pattern, partial boundaries, Main as a plugin, test boundaries
 
 ## Further Reading
 

--- a/clean-code/SKILL.md
+++ b/clean-code/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: clean-code
-description: 'Write readable, maintainable code through disciplined naming, small functions, and clean error handling. Use when the user mentions "code review", "naming conventions", "function too long", "code smells", "readable code", "boy scout rule", "single responsibility", "unit test quality", "my code is hard to read", "this function is a mess", "clean up this code", or "hard to maintain". Also trigger when reviewing pull requests for readability, untangling messy functions, debating comment styles, or improving error handling patterns. Covers SRP, comment discipline, formatting, and unit testing. For refactoring techniques, see refactoring-patterns. For architecture, see clean-architecture.'
+description: 'Write readable, maintainable code through disciplined naming, small functions, and clean error handling. Use when the user mentions "clean up this code", "this function is too long", "code smells", "naming conventions", "boy scout rule", "single responsibility", or "unit test quality". Also trigger when reviewing a pull request for readability, untangling a messy function, debating comment styles, or improving error-handling patterns. Covers SRP, comment discipline, formatting, and unit testing. For refactoring techniques, see refactoring-patterns. For architecture and dependency rules, see clean-architecture.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Clean Code Framework
@@ -52,7 +52,7 @@ Six disciplines for writing code that communicates clearly and adapts to change:
 | **Functions** | Verb + noun | `calculateMonthlyRevenue()` not `calc()` |
 | **Classes** | Noun naming the responsibility | `InvoiceGenerator` not `InvoiceManager` |
 
-See: [references/naming-conventions.md](references/naming-conventions.md)
+See [references/naming-conventions.md](references/naming-conventions.md) when renaming or reviewing names — per-language conventions, pronounceable/searchable tables, and before/after examples.
 
 ### 2. Functions
 
@@ -78,7 +78,7 @@ See: [references/naming-conventions.md](references/naming-conventions.md)
 | **Many arguments** | Introduce parameter object | `new DateRange(start, end)` not `report(start, end, format, locale)` |
 | **Side effects** | Make effects explicit | `checkPassword()` that starts a session → rename or separate |
 
-See: [references/functions-and-methods.md](references/functions-and-methods.md)
+See [references/functions-and-methods.md](references/functions-and-methods.md) when splitting a long function — argument-count rules, command-query separation, and step-down worked examples.
 
 ### 3. Comments and Formatting
 
@@ -102,7 +102,7 @@ See: [references/functions-and-methods.md](references/functions-and-methods.md)
 | **Commented-out code** | Delete it | Trust version control |
 | **Team formatting** | Decide once, automate | Prettier, Black, gofmt |
 
-See: [references/comments-formatting.md](references/comments-formatting.md)
+See [references/comments-formatting.md](references/comments-formatting.md) when deciding whether a comment earns its place — good-vs-bad comment catalog and vertical-formatting rules.
 
 ### 4. Error Handling
 
@@ -127,7 +127,7 @@ See: [references/comments-formatting.md](references/comments-formatting.md)
 | **Special cases** | Null Object pattern | `GuestUser` with default behavior instead of null checks |
 | **Context in errors** | Include operation + state | `"Failed to save invoice #1234 for customer 'Acme'"` |
 
-See: [references/error-handling.md](references/error-handling.md)
+See [references/error-handling.md](references/error-handling.md) when designing exception or null strategy — Special Case pattern and third-party-API wrapping examples.
 
 ### 5. Unit Testing
 
@@ -151,7 +151,7 @@ See: [references/error-handling.md](references/error-handling.md)
 | **Shared setup** | Builder/factory helpers | `aUser().withRole(ADMIN).build()` |
 | **Flaky tests** | Remove external dependencies | Mock time, network, file system |
 
-See: [references/testing-principles.md](references/testing-principles.md)
+See [references/testing-principles.md](references/testing-principles.md) when writing or cleaning tests — TDD laws, F.I.R.S.T. expanded, and clean-test patterns.
 
 ### 6. Code Smells and Heuristics
 
@@ -176,7 +176,7 @@ See: [references/testing-principles.md](references/testing-principles.md)
 | **Magic numbers** | Named constants | `MAX_LOGIN_ATTEMPTS = 5` not bare `5` |
 | **Shotgun surgery** | Consolidate related changes | Group scattered logic into a single module |
 
-See: [references/code-smells.md](references/code-smells.md)
+See [references/code-smells.md](references/code-smells.md) when a smell is hard to name — the full catalog by category, each paired with its targeted refactoring.
 
 ## Common Mistakes
 
@@ -204,8 +204,8 @@ See: [references/code-smells.md](references/code-smells.md)
 | Does every class have a single responsibility? | Classes accumulate unrelated duties | Split into focused, well-named classes |
 | Is there a test for every public method? | No safety net for changes | Add tests before changing further |
 | Are test names descriptive of behavior? | Failures are hard to interpret | Rename to `shouldDoXWhenY` |
-| Is duplication below 3 occurrences? | Copy-paste spreading bugs | Extract a shared function or module |
-| Are magic numbers named constants? | Intent hidden behind raw values | Extract descriptive constants |
+| Is duplication below 3 occurrences? | Copy-paste spreading bugs | Extract shared logic (§6) |
+| Are magic numbers named constants? | Intent hidden behind raw values | Name the constant (§6) |
 | Do all tests run in under 10 seconds? | Slow tests don't get run | Mock external deps; split integration tests |
 
 ## Reference Files

--- a/clean-code/SKILL.md
+++ b/clean-code/SKILL.md
@@ -208,15 +208,6 @@ See [references/code-smells.md](references/code-smells.md) when a smell is hard 
 | Are magic numbers named constants? | Intent hidden behind raw values | Name the constant (§6) |
 | Do all tests run in under 10 seconds? | Slow tests don't get run | Mock external deps; split integration tests |
 
-## Reference Files
-
-- [naming-conventions.md](references/naming-conventions.md): Intention-revealing names, avoiding disinformation, class vs. method naming, before/after examples
-- [functions-and-methods.md](references/functions-and-methods.md): Small functions, argument counts, command-query separation, the step-down rule, side effects
-- [comments-formatting.md](references/comments-formatting.md): Good vs. bad comments, the newspaper metaphor, vertical formatting, team rules
-- [error-handling.md](references/error-handling.md): Exceptions over return codes, null handling, Special Case pattern, wrapping third-party APIs
-- [testing-principles.md](references/testing-principles.md): TDD laws, F.I.R.S.T. principles, clean test patterns, test readability
-- [code-smells.md](references/code-smells.md): Comprehensive smell catalog organized by category, with targeted refactorings
-
 ## Further Reading
 
 Based on Robert C. Martin's seminal guide to software craftsmanship:

--- a/cold-start-problem/SKILL.md
+++ b/cold-start-problem/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: cold-start-problem
-description: 'Start and scale networked products using Andrew Chen''s "The Cold Start Problem" framework for network effects. Use when the user mentions "network effects", "chicken and egg", "cold start", "two-sided marketplace", "atomic network", "hard side", "liquidity", "critical mass", "invite-only launch", "no one uses it because no one uses it", "how do I get my first users", or "the marketplace has no buyers or sellers". Also trigger when launching a marketplace, social, or collaboration product that is worthless without other users, deciding launch sequencing and seeding tactics, or diagnosing stalled network growth at scale. Covers the five stages: cold start, tipping point, escape velocity, hitting the ceiling, and the moat. For word-of-mouth virality, see contagious. For habit-driven retention, see hooked-ux.'
+description: 'Start and scale networked products using Andrew Chen''s "The Cold Start Problem" framework for network effects. Use when the user mentions "network effects", "chicken and egg", "cold start", "two-sided marketplace", "atomic network", "hard side", "liquidity", "critical mass", "invite-only launch", "how do I get my first users", or "the marketplace has no buyers or sellers". Also trigger when launching a marketplace, social, or collaboration product that is worthless without other users, deciding launch sequencing and seeding tactics, or diagnosing stalled network growth at scale. Covers the five stages: cold start, tipping point, escape velocity, hitting the ceiling, and the moat. For word-of-mouth virality, see contagious. For habit-driven retention, see hooked-ux.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # The Cold Start Problem
@@ -48,7 +48,7 @@ A framework for starting and scaling products that live or die by network effect
 | Growth diagnosis | Attribute growth to the three effects separately | Viral factor vs. session frequency vs. conversion, each per network |
 | Strategy review | Map the product as a network of networks | A marketplace is one network per city-category pair |
 
-See: [references/case-studies.md](references/case-studies.md)
+See [references/case-studies.md](references/case-studies.md) for three end-to-end worked scenarios — a B2B tool finding its atomic network, a services marketplace seeding one city, a social app recovering from a big-bang launch — when you want a full example to model a plan on.
 
 ### 2. The Cold Start: Atomic Networks
 
@@ -68,12 +68,12 @@ See: [references/case-studies.md](references/case-studies.md)
 | Context | Application | Example |
 |---------|-------------|---------|
 | Launch scoping | Pick a network, not a market | "Agents in one Austin brokerage," not "the US housing market" |
-| Activation | Define and instrument the magic moment | Team exchanges 2,000 messages → long-term retention bar |
+| Activation | Define and instrument the magic moment | New member posts and gets a teammate reply within minutes |
 | Empty side | Flintstone missing supply manually | Founders personally fulfill the first 100 marketplace orders |
 
 **Ethical boundary:** Flintstoning means doing real work manually behind the scenes — never fabricating fake users, reviews, or activity that deceives the people on the network.
 
-See: [references/atomic-networks.md](references/atomic-networks.md)
+See [references/atomic-networks.md](references/atomic-networks.md) when scoping the first launch — it has the 5-step minimum-size derivation, the actor/action/response/time magic-moment template, instrumentation and zero-rate steps, honest-flintstoning rules, single-player fallbacks, and a launch checklist.
 
 ### 3. Solve the Hard Side
 
@@ -98,7 +98,7 @@ See: [references/atomic-networks.md](references/atomic-networks.md)
 
 **Ethical boundary:** Hard-side economics must be honest — present launch subsidies as temporary incentives, and never build people's livelihoods on terms you plan to quietly degrade.
 
-See: [references/hard-side.md](references/hard-side.md)
+See [references/hard-side.md](references/hard-side.md) when designing supply-side acquisition and economics — it maps money/status/utility motivations to product investments and details three named playbooks (tools-first, content-first, subsidies).
 
 ### 4. Tipping Point and Escape Velocity
 
@@ -123,7 +123,7 @@ See: [references/hard-side.md](references/hard-side.md)
 
 **Ethical boundary:** Scarcity and exclusivity must be real — fake waitlists and manufactured "limited spots" are deception, not strategy.
 
-See: [references/tipping-playbooks.md](references/tipping-playbooks.md)
+See [references/tipping-playbooks.md](references/tipping-playbooks.md) when planning network #2 onward — invite-only and referral-tree mechanics, paid-launch and supply pre-commitment tactics, market selection, anti-patterns, and the liquidity metrics to gate on.
 
 ### 5. The Ceiling and the Moat
 
@@ -149,7 +149,7 @@ See: [references/tipping-playbooks.md](references/tipping-playbooks.md)
 
 **Ethical boundary:** Fixing revolts and spam means addressing root causes for users — not silencing legitimate hard-side grievances with PR.
 
-See: [references/scale-ceiling-moat.md](references/scale-ceiling-moat.md)
+See [references/scale-ceiling-moat.md](references/scale-ceiling-moat.md) when growth stalls or a rival appears — it runs the three forces as growth workstreams, diagnoses which ceiling hit first, and details quality interventions and cherry-picking defense at scale.
 
 ## Common Mistakes
 
@@ -176,14 +176,6 @@ See: [references/scale-ceiling-moat.md](references/scale-ceiling-moat.md)
 | Are you measuring liquidity (fill rate, time-to-match)? | Growth optics hide network health | Add per-network density metrics to the core dashboard |
 | Do you know which ceiling will hit first? | The stall will arrive as a mystery | Model saturation, CAC creep, and quality decay now |
 | Is anything defending the hard side from rivals? | Cherry-pickers will peel off your best segments | Deepen hard-side economics and pro tooling |
-
-## Reference Files
-
-- [references/atomic-networks.md](references/atomic-networks.md) — Choosing and launching the smallest viable network: constraints, minimum-size logic, magic-moment instrumentation, flintstoning, single-player fallbacks, sequencing networks #2..N
-- [references/hard-side.md](references/hard-side.md) — Identifying the hard side, motivation mapping (money/status/utility), acquisition playbooks (tools-first, content-first, subsidies), pro-feature design, balancing both sides
-- [references/tipping-playbooks.md](references/tipping-playbooks.md) — Invite-only mechanics, waitlists and referral trees, paid launches, supply pre-commitment, market selection, anti-patterns, liquidity metrics
-- [references/scale-ceiling-moat.md](references/scale-ceiling-moat.md) — The three forces as growth workstreams, diagnosing ceilings, quality interventions at scale, moat and cherry-picking defense
-- [references/case-studies.md](references/case-studies.md) — Three scenarios: a B2B tool finds its atomic network, a services marketplace seeds one city, a social app recovers from a big-bang launch
 
 ## Further Reading
 

--- a/contagious/SKILL.md
+++ b/contagious/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: contagious
-description: 'Engineer word-of-mouth and virality using the STEPPS framework (Social Currency, Triggers, Emotion, Public, Practical Value, Stories). Use when the user mentions "go viral", "word of mouth", "shareable content", "social currency", "why people share", "viral loop", "referral program", "organic growth", "how do I get people to share this", "nobody is sharing it", or "make this spread". Also trigger when designing shareable features, crafting social campaigns, or building products that spread through peer recommendation. Covers environmental triggers and high-arousal emotional content. For sticky messaging, see made-to-stick. For persuasion tactics, see influence-psychology.'
+description: 'Engineer word-of-mouth and virality using the STEPPS framework (Social Currency, Triggers, Emotion, Public, Practical Value, Stories). Use when the user mentions "go viral", "word of mouth", "shareable content", "social currency", "why people share", "referral program", "nobody is sharing it", or "make this spread". Also trigger when designing shareable features, crafting social campaigns, or building products that spread through peer recommendation. Covers environmental triggers and high-arousal emotional content. For sticky messaging, see made-to-stick. For persuasion tactics, see influence-psychology.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Word-of-Mouth & Virality Framework
@@ -15,9 +15,16 @@ A framework for engineering word-of-mouth and making products, ideas, and conten
 
 **Virality is not born — it is engineered.** Products spread because they were designed — consciously or not — to be shared. Only 7% of word-of-mouth happens online; the other 93% happens in offline conversations, so virality is about the psychology of sharing, not social media mechanics. Those psychological patterns are predictable and can be engineered into anything using the STEPPS framework.
 
+See: [references/word-of-mouth.md](references/word-of-mouth.md) when the brief over-indexes on social media — it makes the offline-vs-online case, lists conversation triggers, and gives a WOM measurement/audit method.
+
 ## Scoring
 
-**Goal: 10/10.** Rate any product, campaign, content, or feature 0-10 on how many STEPPS drivers it activates and how well. Report the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score each of the six STEPPS drivers (the six Quick Diagnostic rows) — **0** absent, **1** present but weak, **2** strong and deliberate — for a raw 0-12, then map: 11-12 -> 10, 9-10 -> 8-9, 6-8 -> 6-7, 3-5 -> 4-5, 0-2 -> <=3. Bands:
+- **9-10** — three or more drivers at strength 2, at least one of them Public or Social Currency (the self-propagating ones), and the brand survives the Trojan Horse test.
+- **6-8** — two drivers genuinely strong, but spread still leans on paid reach or product quality alone.
+- **<=5** — at most one weak driver; sharing is incidental, not engineered.
+
+Report the raw count, the mapped score, and the specific driver(s) to raise next to reach 10/10.
 
 ## STEPPS Overview
 
@@ -38,7 +45,7 @@ A framework for engineering word-of-mouth and making products, ideas, and conten
 
 **Core concept:** People share things that make them look good — smart, cool, in-the-know. Make people feel like insiders and they'll spread it to boost their own image.
 
-**Why it works:** Brands and information are social signals; people don't just share what they think — they share what makes them look good for thinking it.
+**Why it works:** Sharing is self-presentation — listeners infer the sharer's traits from what they pass on, so people curate shares the way they curate clothes. Mechanism: give the sharer a payoff in status or identity and you outsource your marketing to their ego.
 
 **Key insights:**
 - **Remarkability** — surprising, novel, or extreme things make the sharer seem interesting; "Did you know...?" is a powerful sharing trigger
@@ -61,7 +68,7 @@ A framework for engineering word-of-mouth and making products, ideas, and conten
 
 **Ethical boundary:** Create real insider value, not false scarcity or manufactured exclusivity that breeds toxicity.
 
-See: [references/social-currency.md](references/social-currency.md) for remarkability exercises and game mechanics design.
+See: [references/social-currency.md](references/social-currency.md) when a product feels unremarkable — it has the inner-remarkability exercise, game-mechanic design, exclusivity types, and a scored audit.
 
 ### 2. Triggers
 
@@ -90,7 +97,7 @@ See: [references/social-currency.md](references/social-currency.md) for remarkab
 
 **Ethical boundary:** Build genuine, helpful associations — hijacking sensitive contexts (grief, health scares) as triggers backfires.
 
-See: [references/triggers.md](references/triggers.md) for habitat analysis and trigger design frameworks.
+See: [references/triggers.md](references/triggers.md) when picking a cue to attach to — it has the habitat-analysis worksheet, the frequency matrix, and the 4-step trigger design process.
 
 ### 3. Emotion
 
@@ -119,13 +126,13 @@ See: [references/triggers.md](references/triggers.md) for habitat analysis and t
 
 **Ethical boundary:** Engineering outrage for clicks corrodes trust — use high-arousal negative emotion sparingly and only when the cause genuinely warrants it.
 
-See: [references/emotion.md](references/emotion.md) for emotional arousal mapping and content audit tools.
+See: [references/emotion.md](references/emotion.md) when content feels flat — it has the emotion-sharing matrix, awe-engineering techniques, and humor design rules.
 
 ### 4. Public
 
 **Core concept:** Built to show, built to grow. If people can see others using your product, they're more likely to adopt it — design for observability.
 
-**Why it works:** People imitate what they can see; invisible usage forfeits the most powerful adoption channel, social proof through observation.
+**Why it works:** Visible choices resolve uncertainty for the observer — seeing others use a product lowers their perceived risk and supplies social proof at zero marginal cost, so observability turns each user into a passive, continuous billboard.
 
 **Key insights:**
 - **Behavioral residue** — design visible traces that outlast use: a Livestrong wristband long outlives the donation
@@ -147,7 +154,7 @@ See: [references/emotion.md](references/emotion.md) for emotional arousal mappin
 
 **Ethical boundary:** Visibility must empower, never shame — users always control what becomes public, and private data (failures, health, finances) stays private.
 
-See: [references/public-visibility.md](references/public-visibility.md) for observability design and behavioral residue strategies.
+See: [references/public-visibility.md](references/public-visibility.md) when usage is invisible — it has the public-vs-private breakdown, the behavioral-residue design checklist, and the Apple-logo design lesson.
 
 ### 5. Practical Value
 
@@ -176,7 +183,7 @@ See: [references/public-visibility.md](references/public-visibility.md) for obse
 
 **Ethical boundary:** Value must be genuine — inflated "original" prices and clickbait life hacks destroy trust faster than they generate shares.
 
-See: [references/practical-value.md](references/practical-value.md) for Prospect Theory applications and knowledge packaging formats.
+See: [references/practical-value.md](references/practical-value.md) when framing a deal or packaging tips — it applies Prospect Theory, the Rule of 100 quick reference, and the knowledge-packaging hierarchy.
 
 ### 6. Stories
 
@@ -205,11 +212,11 @@ See: [references/practical-value.md](references/practical-value.md) for Prospect
 
 **Ethical boundary:** Stories must be true or clearly fictional — fabricated testimonials and invented origins eventually surface and poison future word-of-mouth.
 
-See: [references/stories-trojan-horse.md](references/stories-trojan-horse.md) for narrative templates and the Trojan Horse integration test.
+See: [references/stories-trojan-horse.md](references/stories-trojan-horse.md) when shaping the narrative — it has the brand-integration test and four story templates (demo, stunt, origin, customer-hero).
 
 ## Engineering Word of Mouth
 
-STEPPS principles compound when combined:
+STEPPS principles compound when combined. See: [references/case-studies.md](references/case-studies.md) for end-to-end STEPPS breakdowns (Blendtec, Barclay Prime, Kit Kat, Livestrong, Dove, Hotmail) when you need a worked precedent to model a campaign on.
 
 ### Product Launch
 
@@ -228,6 +235,8 @@ STEPPS principles compound when combined:
 | How-to guides | Practical Value | Triggers | Tips tied to recurring situations |
 | Brand films | Emotion | Stories | Awe-inspiring narrative with brand at center |
 | Interactive tools | Practical Value | Public | Calculator/quiz with shareable results |
+
+See: [references/viral-content-patterns.md](references/viral-content-patterns.md) when choosing a content format — it ranks formats by shareability, gives platform-specific patterns, and defines the viral coefficient.
 
 ### Feature Design
 
@@ -259,18 +268,6 @@ STEPPS principles compound when combined:
 | Can others see people using it? | Invisible usage | Add observable signals or branded outputs |
 | Is it useful enough to forward? | Low practical value | Package as tips, lists, or tools people would send a friend |
 | Is the brand embedded in a retellable story? | No narrative vehicle | Create a Trojan Horse story that needs your brand |
-
-## Reference Files
-
-- [references/social-currency.md](references/social-currency.md) — Remarkability techniques, game mechanics, exclusivity design, identity signaling
-- [references/triggers.md](references/triggers.md) — Habitat analysis, trigger frequency matrix, competitive triggers, Kit Kat case study
-- [references/emotion.md](references/emotion.md) — High vs. low arousal mapping, awe engineering, humor design, emotional audit tools
-- [references/public-visibility.md](references/public-visibility.md) — Behavioral residue, observable consumption, self-advertising products, the Apple logo story
-- [references/practical-value.md](references/practical-value.md) — Prospect Theory for marketers, Rule of 100, knowledge packaging, deal framing
-- [references/stories-trojan-horse.md](references/stories-trojan-horse.md) — Trojan Horse narrative design, brand integration testing, story templates
-- [references/word-of-mouth.md](references/word-of-mouth.md) — Offline vs. online WOM, conversation triggers, measurement, WOM audit
-- [references/viral-content-patterns.md](references/viral-content-patterns.md) — Content formats that spread, platform patterns, viral coefficient, shareability audit
-- [references/case-studies.md](references/case-studies.md) — Breakdowns of Blendtec, Barclay Prime, Kit Kat, Livestrong, Dove, and Hotmail
 
 ## Further Reading
 

--- a/continuous-discovery/SKILL.md
+++ b/continuous-discovery/SKILL.md
@@ -4,7 +4,7 @@ description: 'Build a weekly cadence of customer touchpoints using Opportunity S
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Continuous Discovery Habits Framework
@@ -17,7 +17,7 @@ Framework for building a sustainable weekly practice of customer discovery that 
 
 ## Scoring
 
-**Goal: 10/10.** Rate any discovery practice 0-10: a 10/10 means a weekly interview cadence, a living Opportunity Solution Tree, systematic assumption testing, and evidence-driven build decisions. Report the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score a discovery practice by the seven Quick Diagnostic rows below — start at 3, add 1 point per row answered "yes" (max 10). Bands: **9-10** = weekly cadence, a living Opportunity Solution Tree, systematic assumption testing, and every shipped feature traceable to a customer opportunity; **5-6** = some discovery happening but ad hoc, PM-only, or disconnected from delivery; **≤3** = intuition- and stakeholder-driven with no regular customer contact. Report the current score, the failing rows, and the specific fix for each.
 
 ## Framework
 
@@ -44,7 +44,7 @@ Framework for building a sustainable weekly practice of customer discovery that 
 
 **Ethical boundary:** Never cherry-pick opportunities to justify a predetermined solution — the tree must reflect needs discovered through research.
 
-See: [references/opportunity-trees.md](references/opportunity-trees.md)
+See [references/opportunity-trees.md](references/opportunity-trees.md) when building or auditing a tree — adds the 4-layer diagram, good-vs-poor outcome tables, solution-generation techniques, a weekly update rhythm, healthy/dying-tree signals, two worked examples, and four anti-patterns.
 
 ### 2. Experience Mapping
 
@@ -67,9 +67,7 @@ See: [references/opportunity-trees.md](references/opportunity-trees.md)
 | Churn analysis | Map churned users' experience to find failure points | Users abandon onboarding at step 4 — they lack data they need on hand |
 | Cross-functional alignment | Build the map together | A three-hour collaborative session produces one shared reference artifact |
 
-**Ethical boundary:** Maps must reflect real customer experiences from interviews, not the team's projection of what customers feel.
-
-See: [references/experience-mapping.md](references/experience-mapping.md)
+See [references/experience-mapping.md](references/experience-mapping.md) when mapping a new problem space or churn flow — adds the current-state map template, the experience-vs-journey-map distinction, and the collaborative mapping exercise.
 
 ### 3. Interview Snapshots
 
@@ -94,7 +92,7 @@ See: [references/experience-mapping.md](references/experience-mapping.md)
 
 **Ethical boundary:** Never lead participants toward conclusions — ask open-ended questions about past behavior and let the story reveal what matters.
 
-See: [references/interview-snapshots.md](references/interview-snapshots.md)
+See [references/interview-snapshots.md](references/interview-snapshots.md) when running interviews or setting up recruitment — adds story-based interview structure, the one-page snapshot format, synthesis across snapshots, and how to automate weekly recruitment.
 
 ### 4. Assumption Testing
 
@@ -119,7 +117,7 @@ See: [references/interview-snapshots.md](references/interview-snapshots.md)
 
 **Ethical boundary:** Never deceive participants — painted-door tests should say the feature is coming soon, not fake functionality without disclosure.
 
-See: [references/assumption-mapping.md](references/assumption-mapping.md)
+See [references/assumption-mapping.md](references/assumption-mapping.md) when designing a test for a risky assumption — adds the four assumption types in depth, the importance-vs-evidence 2x2, the test-design menu, and how to set success criteria for leap-of-faith assumptions.
 
 ### 5. Prioritizing Opportunities
 
@@ -142,15 +140,13 @@ See: [references/assumption-mapping.md](references/assumption-mapping.md)
 | Sprint planning | Pick the opportunity with the strongest current evidence | Choose where you have the most interview data and a testable solution |
 | Portfolio decisions | Spread effort by risk and impact | 60% high-confidence, 30% medium, 10% exploratory |
 
-**Ethical boundary:** Prioritization should surface real customer needs, not be gamed to justify features that serve business metrics at users' expense.
-
-See: [references/prioritization-methods.md](references/prioritization-methods.md)
+See [references/prioritization-methods.md](references/prioritization-methods.md) when ranking your top opportunities — adds the opportunity-sizing method, the compare-and-contrast technique, how to weigh data, and how to avoid analysis paralysis.
 
 ### 6. Building the Habit
 
 **Core concept:** Continuous discovery only works as a sustainable weekly habit for the trio — automate recruitment, create lightweight rituals, and embed discovery into the existing workflow rather than treating it as extra work.
 
-**Why it works:** Most teams do a research burst and stop; structural support (automated recruitment, standing slots, shared artifacts) makes the habit compound into deep customer intuition that transforms every decision.
+**Why it works:** Discovery that depends on "finding time" loses to delivery pressure every week; structural support (automated recruitment, standing slots, shared artifacts) removes the per-week decision so the habit survives and compounds.
 
 **Key insights:**
 - The whole trio participates — not just the PM
@@ -169,7 +165,7 @@ See: [references/prioritization-methods.md](references/prioritization-methods.md
 
 **Ethical boundary:** Respect participant time — keep interviews to 30 minutes, compensate fairly, and never disguise a sales pitch as discovery.
 
-See: [references/case-studies.md](references/case-studies.md)
+See [references/case-studies.md](references/case-studies.md) when adapting the habit to your context — worked walkthroughs of continuous discovery in B2B SaaS, consumer mobile, platform, and growth teams.
 
 ## Common Mistakes
 
@@ -194,15 +190,6 @@ See: [references/case-studies.md](references/case-studies.md)
 | Can you trace a shipped feature to a customer opportunity? | Delivery disconnected from discovery | Link backlog items to OST opportunities |
 | Interview snapshots visible to the whole team? | Knowledge trapped in one head | Shared snapshot board, filled after each interview |
 | Comparing opportunities, not just listing them? | Prioritization by opinion | Run a structured comparison on your top 5 |
-
-## Reference Files
-
-- [opportunity-trees.md](references/opportunity-trees.md): OST structure, how to build and maintain one, mapping opportunities to solutions
-- [interview-snapshots.md](references/interview-snapshots.md): Story-based interviewing, snapshot format, synthesis, automating recruitment
-- [assumption-mapping.md](references/assumption-mapping.md): Assumption types, mapping technique, designing tests, leap-of-faith assumptions
-- [experience-mapping.md](references/experience-mapping.md): Current-state maps, identifying pain points, collaborative mapping exercises
-- [prioritization-methods.md](references/prioritization-methods.md): Opportunity scoring, compare-and-contrast, using data, avoiding analysis paralysis
-- [case-studies.md](references/case-studies.md): Continuous discovery applied to B2B SaaS, consumer mobile, platform, and growth teams
 
 ## Further Reading
 

--- a/cro-methodology/SKILL.md
+++ b/cro-methodology/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: cro-methodology
-description: 'Audit websites and landing pages for conversion issues and design evidence-based A/B tests. Use when the user mentions "landing page isnt converting", "conversion rate", "A/B test", "why visitors leave", "objection handling", "bounce rate", "split testing", "conversion funnel", "increase signups", "people add to cart but dont buy", or "improve conversions". Also trigger when diagnosing why signups are low, designing experiment hypotheses, or auditing checkout flows for friction points. Covers funnel mapping, persuasion assets, and objection/counter-objection frameworks. For overall marketing strategy, see one-page-marketing. For usability issues, see ux-heuristics.'
+description: 'Audit websites and landing pages for conversion issues and design evidence-based A/B tests. Use when the user mentions "landing page isnt converting", "conversion rate", "A/B test", "why visitors leave", "objection handling", "bounce rate", "conversion funnel", "increase signups", or "people add to cart but dont buy". Also trigger when diagnosing why signups are low, designing experiment hypotheses, or auditing checkout flows for friction points. Covers funnel mapping, persuasion assets, and objection/counter-objection frameworks. For overall marketing strategy, see one-page-marketing. For usability issues, see ux-heuristics.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # CRO Methodology
@@ -17,7 +17,7 @@ Scientific, customer-centric approach to conversion rate optimization based on t
 
 ## Scoring
 
-**Goal: 10/10.** Rate any landing page, funnel, or conversion flow 0-10 against the principles below. Report the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score any landing page, funnel, or conversion flow against the seven Quick Diagnostic rows below: award ~1.4 points per row answered "yes" (7 rows = 9.8, capped at 10). Bands: **9-10** = single clear action, research-grounded O/CO table, value prop legible in 5 seconds, proof at every friction point, funnel mapped, path free of UX blockers; **5-6** = guessed objections, generic best-practices copy, proof buried in FAQs; **<=3** = competing CTAs, no funnel map, claims with no proof. Report the current score and the specific diagnostic rows failing.
 
 ## The CRO Frameworks
 
@@ -46,11 +46,8 @@ Scientific, customer-centric approach to conversion rate optimization based on t
 **Copy patterns:**
 - "What's preventing you from [action] today?" (exit survey to discover objections)
 - "Here's what [X] customers found..." (counter-objection with social proof)
-- Hypothesis template: "If we [change X], then [metric Y] will improve because [reason from research]"
 
-**Ethical boundary:** Never manipulate test results or cherry-pick data; report all tests, including failures.
-
-See: [testing-methodology.md](references/testing-methodology.md) for ICE scoring, A/B vs. multivariate guidance, and statistical rigor.
+See [funnel-analysis.md](references/funnel-analysis.md) when mapping the funnel -- step-by-step mapping, blocked-artery/missing-link diagnosis, industry funnel benchmarks, and impact-based prioritization.
 
 ### 2. Customer Research & Objections
 
@@ -79,7 +76,7 @@ See: [testing-methodology.md](references/testing-methodology.md) for ICE scoring
 
 **Ethical boundary:** Anonymize data, get consent for recordings, and don't survey so aggressively that you degrade the experience.
 
-See: [RESEARCH.md](references/RESEARCH.md) for tools, survey questions, and data analysis methods.
+See [RESEARCH.md](references/RESEARCH.md) when planning research -- ready-to-use survey questions per channel, recommended tools, and how to turn raw responses into a ranked objection list.
 
 ### 3. Persuasion Assets
 
@@ -109,13 +106,13 @@ See: [RESEARCH.md](references/RESEARCH.md) for tools, survey questions, and data
 
 **Ethical boundary:** Never fabricate testimonials, inflate statistics, or display fake trust badges -- all proof must be genuine and verifiable.
 
-See: [PERSUASION.md](references/PERSUASION.md) for the full persuasion assets checklist and psychological triggers.
+See [PERSUASION.md](references/PERSUASION.md) when auditing or acquiring proof -- the full five-category asset checklist and psychological triggers. See [COPYWRITING.md](references/COPYWRITING.md) when writing the proof copy itself -- headline formulas, benefit-led phrasing, and proof-element wording.
 
 ### 4. The O/CO Framework
 
 **Core concept:** The Objection/Counter-Objection table is the core CRE technique: map every visitor objection to a specific, evidence-backed counter-objection.
 
-**Why it works:** Visitors arrive with objections; if the page doesn't address them, they leave. The O/CO table ensures no objection goes unanswered, each counter placed where the objection arises in the reading flow.
+**Why it works:** The table forces every counter to be placed where its objection arises in the reading flow, so a concern is answered the instant the visitor feels it -- not pages later, by which point they have already left.
 
 **Key insights:**
 - Research objections from surveys, chat logs, tickets, and sales calls -- don't guess
@@ -139,9 +136,9 @@ See: [PERSUASION.md](references/PERSUASION.md) for the full persuasion assets ch
 - Good (CO Only): "Let the audio do the work for you."
 - "What almost stopped you from buying?" (post-purchase survey to validate the O/CO table)
 
-**Ethical boundary:** Address real objections honestly -- never dismiss legitimate concerns or use deception to overcome valid hesitations.
+**Ethical boundary:** A counter-objection must resolve the concern with real evidence, not dismiss a legitimate worry as unfounded.
 
-See: [OBJECTIONS.md](references/OBJECTIONS.md) for the full O/CO framework, research methods, and counter-objection techniques.
+See [OBJECTIONS.md](references/OBJECTIONS.md) when building the O/CO table -- per-category counter-objection technique catalogs, CO-Only patterns for implicit objections, and how to mine objections from support logs.
 
 ### 5. Hypothesis Design
 
@@ -152,23 +149,16 @@ See: [OBJECTIONS.md](references/OBJECTIONS.md) for the full O/CO framework, rese
 **Key insights:**
 - Format: "If we [change X], then [metric Y] will improve because [reason based on research]"
 - Define primary (decides winner), secondary (monitoring), and guardrail (must not decrease) metrics before testing
-- ICE, 1-10 each: Impact (could this double conversion?), Confidence (how strong is the research?), Ease (how easy to implement?)
-- Worth testing: complete redesign, new value proposition, fundamentally different offer. Not worth testing: button color, font size, image swap
-- Before testing, ask: "Could this 10x our results?" If not, reconsider priority
+- ICE, 1-10 each: Impact (could this double conversion?), Confidence (how strong is the research?), Ease (how easy to implement?); prioritize by the average
+- The 10x screen: if a change couldn't 10x results, deprioritize it. Worth testing: complete redesign, new value proposition, fundamentally different offer. Not worth testing: button color, font size, image swap
 
-**Product applications:**
-
-| Context | Hypothesis Example | ICE Score |
-|---------|-------------------|-----------|
-| **Headline rewrite** | "Customer language from surveys will lift conversion because visitors see their own words" | I:8, C:9, E:10 = 9.0 |
-| **Checkout redesign** | "One-page checkout will lift completion because analytics show 40% drop at step 2" | I:9, C:6, E:3 = 6.0 |
-| **Button color** | "Green button will lift clicks because green means go" | I:2, C:2, E:10 = 4.7 (skip) |
+**Worked example:** "Customer language from surveys will lift signups because visitors see their own words" scores I:8, C:9, E:10 = 9.0 -- a top-priority test. A button-color swap scores ~I:2, C:2, E:10 = 4.7 and gets skipped despite being trivial to build.
 
 **Copy patterns:**
 - "Based on our research, visitors' #1 objection is [X]. This test addresses it by [Y]."
 - Document before: hypothesis, primary metric, sample size, duration. Document after: raw numbers, confidence interval, learnings, next steps
 
-**Ethical boundary:** Report all results honestly -- never cherry-pick data or rerun tests until you get the answer you want.
+See [testing-methodology.md](references/testing-methodology.md) when prioritizing or scoring a backlog -- per-axis ICE scoring rubrics, a worked prioritization table, and the weighted-ICE variant.
 
 ### 6. A/B Testing Methodology
 
@@ -189,7 +179,7 @@ See: [OBJECTIONS.md](references/OBJECTIONS.md) for the full O/CO framework, rese
 | Context | Test Type | Example |
 |---------|----------|---------|
 | **Concept validation** | A/B test (2-4 variants) | Two fundamentally different layouts based on different customer insights |
-| **Low traffic** | Bold A/B test | Dramatic changes detectable with smaller samples (~4,000 visitors for 50% lift) |
+| **Low traffic** | Bold A/B test | Dramatic changes reach significance on far smaller samples than timid ones |
 | **Post-test** | Scale wins | Apply winning insights to landing pages, ad copy, email sequences |
 
 **Copy patterns:**
@@ -197,7 +187,7 @@ See: [OBJECTIONS.md](references/OBJECTIONS.md) for the full O/CO framework, rese
 - "Test showed no significant difference, teaching us that [insight about customers]"
 - Document learnings: Test, Hypothesis, Result, Learning, Applicable to
 
-**Ethical boundary:** Never manipulate statistics to manufacture significance; report confidence intervals honestly and acknowledge inconclusive results.
+**Reporting rule:** Decide sample size and duration up front, then report whatever the pre-set test returns -- never stop early on a peeked "winner," rerun a test until it yields the answer you want, or bury an inconclusive result. (This is the one honest-reporting constraint for the whole methodology.)
 
 ## Common Mistakes
 
@@ -224,27 +214,7 @@ Audit any landing page or conversion flow:
 | Is the value proposition clear within 5 seconds? | Visitors bounce before understanding | Run a 5-second test; rewrite headline in customer language |
 | Are persuasion assets visible (testimonials, awards, guarantees)? | Claims without proof aren't believed | Audit assets, acquire missing ones, display prominently |
 | Have we mapped the funnel for blocked arteries? | Optimizing the wrong page | Map traffic per stage, compare to benchmarks, prioritize |
-
-## Quick-Start Checklist
-
-When optimizing any page:
-
-1. [ ] What is the ONE action visitors should take?
-2. [ ] Who are the visitors? What stage of the buying journey?
-3. [ ] What are their top 3-5 objections? (Research, don't guess)
-4. [ ] What proof/counter-objections address each?
-5. [ ] Is the value proposition clear in 5 seconds?
-6. [ ] Are there UX blockers? (speed, mobile, forms)
-7. [ ] What persuasion assets are missing or hidden?
-
-## Reference Files
-
-- [OBJECTIONS.md](references/OBJECTIONS.md): O/CO framework, research methods, counter-objection techniques
-- [COPYWRITING.md](references/COPYWRITING.md): Headlines, proof elements, persuasive writing
-- [PERSUASION.md](references/PERSUASION.md): Persuasion assets checklist, psychological triggers
-- [RESEARCH.md](references/RESEARCH.md): Tools, survey questions, data analysis
-- [testing-methodology.md](references/testing-methodology.md): A/B testing, statistical significance, ICE prioritization, multivariate testing
-- [funnel-analysis.md](references/funnel-analysis.md): Blocked arteries, missing links, industry funnels, cross-sell mapping
+| Is the path free of UX blockers (speed, mobile, form length)? | Friction kills converts who already decided to act | Fix load time, mobile layout, and over-long forms first |
 
 ## Further Reading
 

--- a/crossing-the-chasm/SKILL.md
+++ b/crossing-the-chasm/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: crossing-the-chasm
-description: 'Navigate the technology adoption lifecycle from early adopters to mainstream market. Use when the user mentions "crossing the chasm", "beachhead segment", "whole product", "early adopters vs mainstream", "tech go-to-market", "bowling pin strategy", "technology adoption lifecycle", "pragmatist buyers", "growth stalled after early adopters", "cant get mainstream customers", or "our go-to-market plan". Also trigger when a startup has early traction but cant grow beyond initial users, or when planning go-to-market for a technical product. Covers the D-Day analogy, bowling-pin strategy, and positioning against incumbents. For product positioning, see obviously-awesome. For new market creation, see blue-ocean-strategy.'
+description: 'Navigate the technology adoption lifecycle from early adopters to mainstream market. Use when the user mentions "crossing the chasm", "beachhead segment", "whole product", "early adopters vs mainstream", "tech go-to-market", "bowling pin strategy", "technology adoption lifecycle", "pragmatist buyers", "growth stalled after early adopters", or "our go-to-market plan". Also trigger when planning go-to-market for a technical product. Covers the D-Day analogy, bowling-pin strategy, the tornado, and positioning against incumbents. For product positioning, see obviously-awesome. For new market creation, see blue-ocean-strategy.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Crossing the Chasm Framework
@@ -15,9 +15,17 @@ Strategic framework for marketing and selling disruptive technology products, pa
 
 **There is a chasm between early adopters and the mainstream market.** Most tech companies fail not because they can't build great products, but because they can't cross from visionaries who love new technology to pragmatists who just want solutions that work. The two groups want fundamentally different things -- what wins over innovators actively repels the early majority -- so you must change your strategy, and your whole product, to cross.
 
+If the product is modern PLG/freemium B2B SaaS, read [references/b2b-saas.md](references/b2b-saas.md) first -- it remaps every step below (the chasm, beachhead, whole product, metrics) for self-serve trials, free tiers, and the false-signal trap where 1,000 free users looks like a crossing but isn't.
+
 ## Scoring
 
-**Goal: 10/10.** Rate any tech go-to-market strategy 0-10 against chasm-crossing principles: proper beachhead selection, whole product strategy, and positioning for pragmatist buyers. Low scores mean early-market tactics applied to the mainstream. Report the current score and the improvements needed to reach 10/10.
+**Goal: 10/10.** Score any tech go-to-market by the Quick Diagnostic at the end: count the rows answered "yes" and map the 7 rows onto a 0-10 scale (roughly 1.4 points per satisfied row).
+
+- **9-10:** single dominable beachhead chosen, 10+ in-segment references, whole product complete via partners, evolution-not-revolution positioning, pragmatist-aligned channel -- adoption is accelerating. You've crossed.
+- **5-6:** beachhead picked but whole product or references still thin, or positioning still reads "revolutionary." You're mid-chasm; ship the missing whole-product layers and case studies.
+- **<=3:** multiple beachheads (or none), visionary messaging, MVP-grade product. Classic early-market tactics aimed at the mainstream -- the most common reason to stall.
+
+Report the score, name the failing diagnostic rows, and give the fix for each.
 
 ## The Technology Adoption Life Cycle
 
@@ -51,13 +59,9 @@ Innovators → Early Adopters → [CHASM] → Early Majority → Late Majority �
 
 **Why this matters:** You can't market to both simultaneously -- visionary testimonials scare off pragmatists.
 
-See: [references/buyer-segments.md](references/buyer-segments.md) for detailed buyer psychographics.
+See: [references/buyer-segments.md](references/buyer-segments.md) when you need to identify which group a specific prospect belongs to, or to write segment-specific messaging -- it has full psychographics and buying triggers per group.
 
-## Why the Chasm Exists
-
-- **Reference gap:** The early majority won't buy without references from other early majority companies -- but none exist until someone crosses first. Classic catch-22.
-- **Whole product gap:** Early adopters tolerate incomplete products; the early majority demands complete, integrated solutions. The MVP that wowed visionaries is unshippable to pragmatists.
-- **Positioning gap:** "Revolutionary" excites early adopters and terrifies the early majority, who read "disruptive" as risky, expensive, unproven. Pragmatists want evolution, not revolution.
+**The reference catch-22:** Pragmatists won't buy without references from other pragmatists -- but none exist until someone crosses first. This is *why* the chasm is a chasm and not a slope: the social proof the early majority requires cannot accumulate gradually. Breaking it is the whole game (Steps 1-2 below).
 
 ## The D-Day Strategy: Crossing the Chasm
 
@@ -81,7 +85,7 @@ See: [references/buyer-segments.md](references/buyer-segments.md) for detailed b
 
 **Process:** Brainstorm 20+ segments, score each against the criteria, choose ONE (resist keeping options open), commit to dominating it.
 
-See: [references/beachhead-selection.md](references/beachhead-selection.md) for segment evaluation frameworks.
+See: [references/beachhead-selection.md](references/beachhead-selection.md) when running the brainstorm-and-score step above -- it has the scoring matrix, weighting, and the target-customer characterization worksheet to pick the one segment.
 
 ### Step 2: Assemble the Invasion Force
 
@@ -110,7 +114,7 @@ Whole product layers: Generic (what you ship) → Expected (minimum viable) → 
 
 **Partnerships:** Identify gaps between generic and augmented, partner with companies that fill them, go to market jointly for the beachhead.
 
-See: [references/whole-product.md](references/whole-product.md) for whole product planning.
+See: [references/whole-product.md](references/whole-product.md) when mapping your gaps -- it extends the layers above with a 12-row gap-analysis matrix, the 80% rule, support-tier SLAs, and a planning canvas.
 
 ### Step 3: Define the Battle
 
@@ -128,7 +132,7 @@ See: [references/whole-product.md](references/whole-product.md) for whole produc
 
 **Competitive positioning:** The market alternative is often NOT a direct competitor -- it's manual processes, spreadsheets, or legacy systems. Differentiate on a dimension you dominate and make the incumbent's strength irrelevant: Salesforce's "No software" positioning turned feature-rich Siebel's complexity into a weakness.
 
-See: [references/positioning.md](references/positioning.md) for competitive positioning frameworks.
+See: [references/positioning.md](references/positioning.md) when filling in the formula above or choosing the competitive alternative to displace -- it has the claim-and-evidence structure and the "make the incumbent's strength irrelevant" patterns.
 
 ### Step 4: Launch the Invasion
 
@@ -151,7 +155,7 @@ See: [references/positioning.md](references/positioning.md) for competitive posi
 | "Change everything" | "Improve [specific metric] by X%" |
 | "Visionary" | "Pragmatic" |
 
-See: [references/go-to-market.md](references/go-to-market.md) for launch strategies.
+See: [references/go-to-market.md](references/go-to-market.md) when building the launch plan -- it details channel selection by buyer type, the reference-and-case-study engine, and pricing/pilot tactics for pragmatists.
 
 ## Bowling Pin Strategy
 
@@ -163,7 +167,7 @@ See: [references/go-to-market.md](references/go-to-market.md) for launch strateg
 
 **Anti-pattern:** Jumping to distant segments before dominating the beachhead.
 
-See: [references/expansion.md](references/expansion.md) for segment expansion strategies.
+See: [references/expansion.md](references/expansion.md) when sequencing your next 2-3 segments -- adjacency scoring and the bowling-pin ordering rules. For full worked arcs (Salesforce, VMware, Zoom, Atlassian) and stuck-in-the-chasm failures (Palm, Segway), see [references/case-studies.md](references/case-studies.md) when you need a pattern-match for your own situation.
 
 ## The Tornado: After the Chasm
 
@@ -185,38 +189,17 @@ See: [references/expansion.md](references/expansion.md) for segment expansion st
 
 ## Quick Diagnostic
 
-Audit any tech product go-to-market:
+Audit any tech go-to-market, and re-run it as the completion gate before declaring the chasm crossed. Each "If No" is a chasm symptom; act on the failing rows first.
 
 | Question | If No | Action |
 |----------|-------|--------|
-| Have we chosen a single beachhead segment? | You're in the chasm | Define narrow target market |
-| Do we have references from that segment? | Pragmatists won't buy | Build lighthouse customers |
-| Is the whole product complete? | Product won't meet needs | Identify gaps, build partnerships |
-| Does positioning emphasize proven value? | Wrong message for early majority | Reframe: evolution not revolution |
-| Can we dominate this segment? | Wrong beachhead | Choose narrower or different segment |
-
-## Chasm-Crossing Checklist
-
-**Before declaring victory:**
-- [ ] Single, narrowly defined beachhead segment chosen
-- [ ] Segment has urgent, expensive problem
-- [ ] We can assemble whole product for segment
-- [ ] 10+ reference customers from beachhead segment
-- [ ] Positioning emphasizes proven value, not revolution
-- [ ] Distribution channel aligned with pragmatist buying behavior
-- [ ] Partnerships in place to deliver whole product
-- [ ] Metrics show adoption accelerating (moving into tornado)
-
-## Reference Files
-
-- [buyer-segments.md](references/buyer-segments.md): Detailed psychographics for each buyer type
-- [beachhead-selection.md](references/beachhead-selection.md): Segment evaluation, scoring frameworks
-- [whole-product.md](references/whole-product.md): Whole product planning, gap analysis
-- [positioning.md](references/positioning.md): Competitive positioning frameworks and templates
-- [go-to-market.md](references/go-to-market.md): Distribution, messaging, launch strategies
-- [expansion.md](references/expansion.md): Bowling pin strategy, adjacency criteria
-- [case-studies.md](references/case-studies.md): Salesforce, Documentum, Ariba, and failures
-- [b2b-saas.md](references/b2b-saas.md): Chasm-crossing for modern SaaS companies
+| Have we chosen a single, narrowly defined beachhead with an urgent, expensive problem? | You're in the chasm | Define one narrow target market; resist multiple beachheads |
+| Can we plausibly dominate this segment? | Wrong beachhead | Choose a narrower or different segment |
+| Do we have 10+ reference customers from that exact segment? | Pragmatists won't buy | Build lighthouse customers and case studies |
+| Is the whole product complete -- partnerships in place to fill the gaps? | Product won't meet pragmatist needs | Identify generic-to-augmented gaps, partner to fill them |
+| Does positioning emphasize proven value over revolution? | Wrong message for the early majority | Reframe: evolution, not revolution |
+| Is the distribution channel aligned with pragmatist buying behavior? | You reach visionaries, not pragmatists | Sell through analysts, integrators, references, channel |
+| Are adoption metrics accelerating (entering the tornado)? | Still stuck before the chasm | Re-check the rows above -- something is still early-market |
 
 ## Further Reading
 

--- a/ddia-systems/SKILL.md
+++ b/ddia-systems/SKILL.md
@@ -4,7 +4,7 @@ description: 'Design data systems by understanding storage engines, replication,
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Designing Data-Intensive Applications Framework
@@ -17,7 +17,13 @@ A principled approach to building reliable, scalable, and maintainable data syst
 
 ## Scoring
 
-**Goal: 10/10.** Rate any data architecture 0-10 against the principles below: deliberate trade-off choices for data models, storage, replication, partitioning, transactions, and pipelines score high; accidental complexity and ignored failure modes score low. Report the current score and the improvements needed to reach 10/10.
+**Goal: 10/10.** Score a data architecture by the seven Quick Diagnostic rows below: award ~1.4 points per row answered "yes" with evidence (deliberate, documented trade-off), 0 where the answer is "no" or unknown.
+
+- **9-10:** every domain choice -- data model, storage engine, replication, partitioning, isolation, derived-data, fault handling -- is deliberate, documented, and matched to actual read/write/consistency requirements; failover tested.
+- **5-6:** core choices made but two or three diagnostic rows fail -- e.g. default isolation level unknown, hot-key risk unhandled, or failover untested.
+- **<=3:** choices driven by familiarity, not requirements; ignored failure modes (replication lag, write skew, hot partitions) and accidental complexity dominate.
+
+Report the current score, which diagnostic rows failed, and the improvements needed to reach 10/10.
 
 ## The DDIA Framework
 
@@ -43,13 +49,11 @@ Seven domains for reasoning about data-intensive systems:
 | **Social network connections** | Graph model for relationship traversal | Neo4j Cypher: `MATCH (a)-[:FOLLOWS*2]->(b)` for friend-of-friend |
 | **Financial ledger with joins** | Relational model for referential integrity | PostgreSQL foreign keys between accounts, transactions, entries |
 
-See: [references/data-models.md](references/data-models.md) for relational/document/graph trade-offs and query language comparisons.
+See [references/data-models.md](references/data-models.md) when picking relational vs document vs graph or evaluating schema-on-read -- adds the full trade-off matrix and query-language comparisons.
 
 ### 2. Storage Engines
 
 **Core concept:** Storage engines trade off read performance against write performance. Log-structured engines (LSM trees) optimize writes; page-oriented engines (B-trees) balance reads and writes.
-
-**Why it works:** Understanding your database's storage engine lets you predict performance characteristics, choose appropriate indexes, and avoid pathological workloads.
 
 **Key insights:**
 - LSM trees: append-only writes, periodic compaction, excellent write throughput, higher read amplification
@@ -66,7 +70,7 @@ See: [references/data-models.md](references/data-models.md) for relational/docum
 | **Mixed read/write OLTP** | B-tree engine | PostgreSQL B-tree indexes for transactional point lookups |
 | **Analytical queries** | Column-oriented storage | ClickHouse or Parquet for scanning billions of rows, few columns |
 
-See: [references/storage-engines.md](references/storage-engines.md) for LSM vs B-tree internals, compaction, and column storage.
+See [references/storage-engines.md](references/storage-engines.md) when a workload is read/write-bound or you must choose indexes -- adds write/read-path diagrams, compaction strategies, column storage, and a benchmark-driven decision procedure.
 
 ### 3. Replication
 
@@ -90,13 +94,11 @@ See: [references/storage-engines.md](references/storage-engines.md) for LSM vs B
 | **Multi-region writes** | Multi-leader replication | CockroachDB or Spanner with bounded staleness |
 | **Shopping cart availability** | Leaderless with merge | DynamoDB with last-writer-wins or application-level cart merge |
 
-See: [references/replication.md](references/replication.md) for lag anomalies, conflict resolution, and CRDTs.
+See [references/replication.md](references/replication.md) when choosing single/multi/leaderless or debugging stale reads -- adds lag anomalies, quorum math, conflict resolution, and CRDTs.
 
 ### 4. Partitioning
 
 **Core concept:** Partitioning (sharding) distributes data across nodes so each handles a subset, enabling horizontal scaling beyond a single machine.
-
-**Why it works:** Without partitioning, one node bottlenecks storage and throughput. Effective partitioning spreads load evenly and avoids hotspots.
 
 **Key insights:**
 - Key-range partitioning supports efficient range scans but risks hotspots on sequential keys
@@ -113,7 +115,7 @@ See: [references/replication.md](references/replication.md) for lag anomalies, c
 | **User data at scale** | Hash partitioning on user ID | Cassandra consistent hashing on `user_id` for even distribution |
 | **Celebrity/hot-key problem** | Key splitting with random suffix | Append random digit to hot key, fan out reads across 10 sub-partitions |
 
-See: [references/partitioning.md](references/partitioning.md) for rebalancing, request routing, and secondary index strategies.
+See [references/partitioning.md](references/partitioning.md) when sharding or fighting a hot key -- adds rebalancing strategies, request routing, and local-vs-global secondary index trade-offs.
 
 ### 5. Transactions and Consistency
 
@@ -136,7 +138,7 @@ See: [references/partitioning.md](references/partitioning.md) for rebalancing, r
 | **Inventory reservation** | SELECT FOR UPDATE to prevent write skew | `SELECT stock FROM items WHERE id = X FOR UPDATE` before decrementing |
 | **Cross-service operations** | Saga instead of distributed transaction | Charge card, reserve inventory; on failure, run compensating refund |
 
-See: [references/transactions.md](references/transactions.md) for isolation-level anomalies and serializability techniques.
+See [references/transactions.md](references/transactions.md) when setting isolation levels or chasing a concurrency bug -- adds per-isolation anomaly tables, write-skew examples, 2PL vs SSI, and distributed-transaction pitfalls.
 
 ### 6. Batch and Stream Processing
 
@@ -160,13 +162,11 @@ See: [references/transactions.md](references/transactions.md) for isolation-leve
 | **Syncing search index** | Change data capture | Debezium captures PostgreSQL WAL, Kafka feeds Elasticsearch |
 | **Audit trail / event replay** | Event sourcing | Store `OrderPlaced`, `OrderShipped` events; rebuild state by replaying |
 
-See: [references/batch-stream.md](references/batch-stream.md) for dataflow engines, CDC, and exactly-once semantics.
+See [references/batch-stream.md](references/batch-stream.md) when designing a pipeline or deriving data from a system of record -- adds dataflow engines, CDC wiring, windowing, and exactly-once techniques.
 
 ### 7. Reliability and Fault Tolerance
 
 **Core concept:** Faults are inevitable; failures are not. A reliable system continues operating correctly even when individual components fail. Design for faults, not against them.
-
-**Why it works:** Hardware fails, software has bugs, humans make mistakes. Systems that assume perfect operation are brittle; systems that expect faults are resilient.
 
 **Key insights:**
 - A fault is one component deviating from spec; a failure is the whole system stopping -- fault tolerance prevents the former becoming the latter
@@ -184,7 +184,7 @@ See: [references/batch-stream.md](references/batch-stream.md) for dataflow engin
 | **Leader election** | Consensus algorithm (Raft/Paxos) | etcd or ZooKeeper for distributed locks and leader election |
 | **Graceful degradation** | Circuit breaker | Resilience4j: open circuit after 50% failures in 10-second window |
 
-See: [references/fault-tolerance.md](references/fault-tolerance.md) for consensus, timeout tuning, and safety/liveness guarantees.
+See [references/fault-tolerance.md](references/fault-tolerance.md) when tuning timeouts/retries or adding consensus -- adds fault classification, timeout-tuning math, Raft/Paxos mechanics, and safety/liveness guarantees.
 
 ## Common Mistakes
 
@@ -209,16 +209,6 @@ See: [references/fault-tolerance.md](references/fault-tolerance.md) for consensu
 | Do you separate system of record from derived data? | Every change requires migrating everything | Introduce CDC or event sourcing to decouple |
 | Are timeouts and retries tuned, not defaulted? | Cascading failures or needless delays | Measure p99; set timeouts above p99, below cascade threshold |
 | Have you tested failover in production conditions? | Recovery plan is theoretical | Run chaos experiments: kill leaders, partition networks, fill disks |
-
-## Reference Files
-
-- [data-models.md](references/data-models.md): Relational vs document vs graph models, schema-on-read vs schema-on-write, query languages, polyglot persistence
-- [storage-engines.md](references/storage-engines.md): LSM trees vs B-trees, write amplification, compaction, column-oriented storage, in-memory databases
-- [replication.md](references/replication.md): Single-leader, multi-leader, leaderless replication, replication lag, conflict resolution, CRDTs
-- [partitioning.md](references/partitioning.md): Key-range vs hash partitioning, secondary indexes, rebalancing, request routing, hotspots
-- [transactions.md](references/transactions.md): ACID, isolation levels, write skew, two-phase locking, SSI, distributed transactions
-- [batch-stream.md](references/batch-stream.md): MapReduce, dataflow engines, event sourcing, CDC, stream-table duality, exactly-once semantics
-- [fault-tolerance.md](references/fault-tolerance.md): Faults vs failures, reliability metrics, timeouts, consensus, safety and liveness guarantees
 
 ## Further Reading
 

--- a/design-everyday-things/SKILL.md
+++ b/design-everyday-things/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: design-everyday-things
-description: 'Apply foundational design principles: affordances, signifiers, constraints, feedback, and conceptual models. Use when the user mentions "why is this confusing", "affordance", "error prevention", "discoverability", "human-centered design", "mental model", "mapping", "seven stages of action", "users keep making mistakes", "this is unintuitive", or "people cant figure out how to use it". Also trigger when diagnosing why users err, reducing product complexity, or improving error messages and feedback. Covers the gulfs of execution and evaluation. For usability scoring, see ux-heuristics. For iOS-specific patterns, see ios-hig-design.'
+description: 'Apply foundational design principles: affordances, signifiers, constraints, feedback, and conceptual models. Use when the user mentions "why is this confusing", "affordance", "error prevention", "discoverability", "human-centered design", "mental model", "mapping", "seven stages of action", "users keep making mistakes", "this is unintuitive", or "people cant figure out how to use it". Also trigger when reducing product complexity or feature creep. Covers the gulfs of execution and evaluation. For usability scoring, see ux-heuristics. For iOS-specific patterns, see ios-hig-design.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Design of Everyday Things Framework
@@ -17,7 +17,7 @@ Foundational design principles for creating products that are intuitive, discove
 
 ## Scoring
 
-**Goal: 10/10.** Rate any design 0-10 on discoverability, understandability, and error prevention. A 10/10 means users figure out what to do without instructions, understand what happened, and recover from errors easily. Report the current score and the improvements needed to reach 10/10.
+**Goal: 10/10.** Score 2 points per satisfied row of the Quick Diagnostic (5 rows = discoverability, evaluation, error recovery, mapping, constraints). Bands: **9-10** = users act without instructions, understand every outcome, and recover from any error; **5-6** = one gulf or error path is broken; **<=3** = users must consult a manual or routinely blame themselves. Report the current score and the diagnostic rows failing it.
 
 ## The Two Gulfs
 
@@ -105,7 +105,7 @@ See: [references/affordances.md](references/affordances.md) for affordance desig
 
 **Design rule:** When in doubt, add a signifier — better to over-communicate than leave users guessing.
 
-See: [references/signifiers.md](references/signifiers.md) for signifier patterns and examples.
+See: [references/signifiers.md](references/signifiers.md) when deciding which signifier to add to an unclear control.
 
 ### 4. Mappings
 
@@ -174,7 +174,7 @@ See: [references/constraints.md](references/constraints.md) for constraint desig
 
 **Common failures:** no feedback (did my click register?), delayed feedback (feels broken), unclear feedback, alert overload.
 
-See: [references/feedback.md](references/feedback.md) for feedback design patterns.
+See: [references/feedback.md](references/feedback.md) when an action gives no clear result and you need the right feedback type and timing.
 
 ### 7. Conceptual Models
 
@@ -192,7 +192,7 @@ See: [references/feedback.md](references/feedback.md) for feedback design patter
 
 **Build correct models with:** familiar metaphors (desktop, trash), visible system state, clear feedback, consistent behavior, progressive disclosure.
 
-See: [references/conceptual-models.md](references/conceptual-models.md) for model design frameworks.
+See: [references/conceptual-models.md](references/conceptual-models.md) when the user's model diverges from how the product works. For fully worked teardowns (door handles, thermostats, digital products), see [references/case-studies.md](references/case-studies.md).
 
 ## Human Error
 
@@ -257,21 +257,7 @@ See: [references/seven-stages.md](references/seven-stages.md) for stage-by-stage
 Observation → Idea Generation → Prototyping → Testing → (iterate)
 ```
 
-### 1. Observation
-
-Watch real users in real contexts. Don't ask what they want (they don't know) — look for workarounds, frustrations, and adaptations across whole activities.
-
-### 2. Idea Generation
-
-Generate many ideas before converging; defer judgment and build on others' ideas.
-
-### 3. Prototyping
-
-Quick, cheap, disposable — test concepts, not polish. Paper for early ideas, interactive for validation.
-
-### 4. Testing
-
-Test with real users, not designers: 5 users reveal 85% of problems. Observe behavior, not just opinions, then iterate.
+Two specifics that change how you run this loop: in **Observation**, don't ask users what they want (they don't know) — watch for workarounds and frustrations in real contexts. In **Testing**, use real users not designers — 5 reveal ~85% of problems, so observe behavior over opinions and iterate.
 
 ## Common Mistakes
 
@@ -295,19 +281,6 @@ Audit any design:
 | Can users recover from errors? | No error tolerance | Add undo, confirmation, clear messages |
 | Does the control layout match the output? | Poor mapping | Reorganize controls to match spatial layout |
 | Are impossible/irrelevant options hidden? | Missing constraints | Disable, hide, or remove invalid options |
-
-## Reference Files
-
-- [two-gulfs.md](references/two-gulfs.md): Gulf analysis exercises, bridging strategies
-- [affordances.md](references/affordances.md): Affordance types, design patterns
-- [signifiers.md](references/signifiers.md): Signifier patterns, examples, best practices
-- [mappings.md](references/mappings.md): Natural mapping analysis, spatial layout
-- [constraints.md](references/constraints.md): Constraint types, digital implementations
-- [feedback.md](references/feedback.md): Feedback patterns, timing, modality
-- [conceptual-models.md](references/conceptual-models.md): Model design, metaphors, mental models
-- [human-error.md](references/human-error.md): Error types, prevention, recovery
-- [seven-stages.md](references/seven-stages.md): Stage analysis, evaluation tool
-- [case-studies.md](references/case-studies.md): Door handles, thermostats, digital products
 
 ## Further Reading
 

--- a/design-sprint/SKILL.md
+++ b/design-sprint/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: design-sprint
-description: 'Run a structured 5-day process to prototype, test, and validate product ideas with real users. Use when the user mentions "design sprint", "validate in a week", "rapid prototype", "test with users", "de-risk before building", "GV sprint", "prototype testing", "design workshop", "should we build this", "validate an idea fast", or "test before we build". Also trigger when a team must make a critical product decision quickly, resolve stakeholder disagreements, or test a risky idea before investing in development. Covers mapping, sketching, deciding, prototyping, and testing. For ongoing experimentation, see lean-startup. For customer job analysis, see jobs-to-be-done.'
+description: 'Run a structured 5-day process to prototype, test, and validate product ideas with real users. Use when the user mentions "design sprint", "validate before we build", "rapid prototype", "test with users", or "should we build this". Also trigger when a team is stuck in endless debate over a high-stakes product decision, or wants to de-risk a costly idea before investing in development. Covers mapping, sketching, deciding, prototyping, and testing across Monday-Friday. For ongoing experimentation and MVPs, see lean-startup. For customer job analysis, see jobs-to-be-done. For non-leading user interviews, see mom-test.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Design Sprint Framework
@@ -13,11 +13,24 @@ A five-day process for answering critical business questions through design, pro
 
 ## Core Principle
 
-**Great solutions require both deep work and fast iteration.** The Design Sprint compresses months of debate, design, and testing into one week, replacing endless discussion with focus and urgency. It de-risks product decisions by testing with real users before any production code is written.
+**Compress months of debate, design, and testing into one week — and test with real users before writing any production code.** The sprint replaces endless discussion with a fixed Monday-to-Friday spine, hard time-boxes, and a single Decider, so a high-stakes product question gets a real answer in five days instead of five months.
 
 ## Scoring
 
-**Goal: 10/10.** Rate any sprint plan or execution 0-10 against the principles below: proper structure, time-boxing, prototyping, and user testing. Lower scores mean skipped steps or insufficient testing. Report the current score and the improvements needed to reach 10/10.
+**Goal: 10/10.** Score a sprint plan or execution by awarding 1 point for each item present and correct (10 total). Report the score and the missing items needed to reach 10/10.
+
+1. Decider committed for the full week; one Sprint Master facilitating.
+2. Monday produces a target customer and moment (not a vague "test the product").
+3. Hard time-boxes used (Crazy 8s in 8 min, 10am-5pm days, no open-ended sessions).
+4. Solution sketches done alone and anonymous — no group brainstorming.
+5. Wednesday ends with a single Decider Supervote, not consensus.
+6. Storyboard specified before any prototype is built.
+7. Prototype is a Goldilocks-fidelity facade, testable in 5-15 min, with a trial run done.
+8. Exactly 5 target users recruited via screener (6 scheduled to absorb a no-show).
+9. Friday uses the Five-Act Interview; users interpret the prototype unexplained.
+10. End-of-sprint debrief converts the +/-/~ pattern grid into a decision on next steps.
+
+A plan missing the Decider, real users, or a same-day prototype caps at 6 — those are the failure modes the sprint exists to prevent.
 
 ## The 5-Day Sprint Process
 
@@ -27,6 +40,8 @@ Monday → Tuesday → Wednesday → Thursday → Friday
 ```
 
 **Prerequisites:** a big challenge worth a week's focus; the right team (Decider plus 4-7 people with diverse expertise); five full days (10am-5pm) with no interruptions; a dedicated room with whiteboards. One **Sprint Master** facilitates, keeps time, and manages energy.
+
+See [references/facilitation.md](references/facilitation.md) when you are the Sprint Master — it has the full facilitation guide, time-boxing tactics, and energy-management moves for keeping a stuck or low-energy room productive.
 
 ## Monday: Map
 
@@ -49,7 +64,7 @@ Choose which customer and moment on the map to focus on — the biggest risk or 
 
 **Monday output:** long-term goal, sprint questions, journey map, expert insights, organized HMW notes, target customer and moment.
 
-See: [references/monday.md](references/monday.md) for detailed Monday exercises and facilitation.
+See [references/monday.md](references/monday.md) while facilitating Monday — step-by-step exercise scripts, HMW examples, and the target-selection method.
 
 ## Tuesday: Sketch
 
@@ -71,7 +86,7 @@ Everyone sketches alone — **no group brainstorming**. Individual work produces
 
 **Tuesday output:** one detailed, anonymous, self-explanatory solution sketch per person.
 
-See: [references/tuesday.md](references/tuesday.md) for sketching templates and examples.
+See [references/tuesday.md](references/tuesday.md) before the Four-Step Sketch — Crazy 8s and solution-sketch templates plus worked examples to show the team.
 
 ## Wednesday: Decide
 
@@ -92,7 +107,7 @@ If multiple sketches win, choose: **Rumble** (competing prototypes testing diffe
 
 **Wednesday output:** winning solution(s) and a detailed storyboard ready to prototype.
 
-See: [references/wednesday.md](references/wednesday.md) for decision exercises and storyboard templates.
+See [references/wednesday.md](references/wednesday.md) when running the Sticky Decision and storyboard — facilitation steps for the vote and a panel-by-panel storyboard template.
 
 ## Thursday: Prototype
 
@@ -126,7 +141,7 @@ Morning: divide the storyboard into scenes and assign them to makers. Afternoon:
 
 **Thursday output:** realistic prototype, interview script, prepared interview room.
 
-See: [references/thursday.md](references/thursday.md) for prototyping tools and techniques.
+See [references/thursday.md](references/thursday.md) while building the prototype — tool-by-tool techniques (Keynote/Figma facades, video, mockups) for hitting Goldilocks fidelity in a day.
 
 ## Friday: Test
 
@@ -138,7 +153,7 @@ Interview room: quiet space, laptop with the prototype, camera recording screen 
 
 ### The Five-Act Interview
 
-About 30 minutes per customer, with 30-minute breaks between to discuss observations and adjust questions.
+About 45 minutes per customer (the five acts run ~35 min plus setup and transitions), with 30-minute breaks between to discuss observations and adjust questions. See references/friday.md for the full 9am-5pm schedule.
 
 | Act | Time | What to Do |
 |-----|------|------------|
@@ -150,7 +165,9 @@ About 30 minutes per customer, with 30-minute breaks between to discuss observat
 
 ### Five Is the Magic Number
 
-Patterns emerge after 3-5 people and returns diminish after 5 — and five 1-hour slots fit one day. Recruit target customers via a screener survey, offer an incentive ($100-$200 B2B, $50-$100 B2C), and schedule 6 to absorb a no-show.
+Patterns emerge after 3-5 people and returns diminish after 5 — and five interview-plus-break slots fit one day (see references/friday.md). Recruit target customers via a screener survey and offer an incentive ($100-$200 B2B, $50-$100 B2C).
+
+See [references/recruiting.md](references/recruiting.md) two weeks before the sprint — it has screener-survey questions, recruiting channels, scheduling logistics, and incentive guidance for locking in five on-target users.
 
 ### Take Notes: Pattern Recognition
 
@@ -172,7 +189,7 @@ Organize findings: **✓ what worked** (flows everyone understood, messaging tha
 
 **Friday output:** interview recordings, pattern notes, a clear list of what works and what doesn't, decision on next steps.
 
-See: [references/friday.md](references/friday.md) for interview scripts and note-taking templates.
+See [references/friday.md](references/friday.md) before interviewing — verbatim Five-Act scripts, note-taking templates, the fuller next-steps decision table, and the common Friday mistakes to avoid.
 
 ## When to Run a Design Sprint
 
@@ -180,10 +197,12 @@ See: [references/friday.md](references/friday.md) for interview scripts and note
 
 **Don't run when:** the problem and solution are obvious and you just need to execute, the team isn't bought in, or you can't get the Decider for the full week.
 
+See [references/case-studies.md](references/case-studies.md) for worked sprint walk-throughs (Slack, Blue Bottle Coffee, Savioke and more) when you need a concrete precedent for how a sprint played out in a domain like yours.
+
 ## Variations
 
 - **4-Day Sprint:** Day 1 Map + Sketch (compressed), Day 2 Decide, Day 3 Prototype, Day 4 Test.
-- **Remote Sprint:** Same schedule with Miro/FigJam whiteboards and Zoom.
+- **Remote Sprint:** Same schedule with Miro/FigJam whiteboards and Zoom. See [references/remote-sprints.md](references/remote-sprints.md) when the team is distributed — it adapts each exercise to digital whiteboards, sets remote time-boxes, and handles video-based prototype testing.
 - **Multi-Sprint:** Sprint 1 chooses direction on a broad problem, Sprint 2 deep-dives the chosen solution, Sprint 3 refines details.
 
 ## Common Mistakes
@@ -193,7 +212,7 @@ See: [references/friday.md](references/friday.md) for interview scripts and note
 | **Skip prototyping** | Nothing to test | Always prototype, even if simple |
 | **Over-engineer prototype** | Waste time on details that don't matter | Facade only, not working code |
 | **Test with wrong users** | Invalid feedback | Screen for target customers |
-| **Explain prototype to users** | Defeats the test | Let them struggle, observe confusion |
+| **Explain prototype to users** | Defeats the test; confusion is the data | Run Acts 3-4 as written — they interpret and struggle unaided |
 | **No decision maker** | Can't commit to decision | Get Decider for full week or don't sprint |
 | **Interruptions** | Breaks focus | Protect the week, no meetings/emails |
 
@@ -208,18 +227,6 @@ Audit any sprint plan:
 | Can we prototype in 1 day? | Wrong problem for sprint | Choose more concrete problem |
 | Can we recruit 5 target users? | Can't test properly | Start recruiting now (2 weeks ahead) |
 | Will team commit to no interruptions? | Won't maintain focus | Get buy-in from leadership |
-
-## Reference Files
-
-- [monday.md](references/monday.md): Map exercises, HMW notes, target selection
-- [tuesday.md](references/tuesday.md): Sketching templates, Crazy 8s, solution sketches
-- [wednesday.md](references/wednesday.md): Decision exercises, storyboard templates
-- [thursday.md](references/thursday.md): Prototyping tools, techniques, checklists
-- [friday.md](references/friday.md): Interview scripts, note-taking, pattern analysis
-- [facilitation.md](references/facilitation.md): Sprint Master guide, time-boxing, energy management
-- [recruiting.md](references/recruiting.md): User recruitment, screener surveys, scheduling
-- [case-studies.md](references/case-studies.md): Slack, Blue Bottle Coffee, Savioke, and more
-- [remote-sprints.md](references/remote-sprints.md): Adapting sprint for distributed teams
 
 ## Further Reading
 

--- a/domain-driven-design/SKILL.md
+++ b/domain-driven-design/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: domain-driven-design
-description: 'Model software around the business domain using bounded contexts, aggregates, and ubiquitous language. Use when the user mentions "domain modeling", "bounded context", "aggregate root", "ubiquitous language", "anti-corruption layer", "context mapping", "domain events", "strategic design", "model the business in code", "the code doesnt match the business", or "how do we split this big system". Also trigger when breaking a monolith into services, defining service boundaries, or aligning code structure with business processes. Covers entities vs value objects, domain events, and context mapping strategies. For architecture layers, see clean-architecture. For complexity, see software-design-philosophy.'
+description: 'Model software around the business domain using bounded contexts, aggregates, and ubiquitous language. Use when the user mentions "domain modeling", "bounded context", "aggregate root", "ubiquitous language", "anti-corruption layer", "context mapping", "domain events", "strategic design", "the code doesnt match the business", or "how do we split this big system". Also trigger when breaking a monolith into services, defining service boundaries, or aligning code structure with business processes. Covers entities vs value objects, domain events, and context mapping strategies. For architecture layers, see clean-architecture. For complexity, see software-design-philosophy.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Domain-Driven Design Framework
@@ -17,7 +17,7 @@ Framework for tackling software complexity by modeling code around the business 
 
 ## Scoring
 
-**Goal: 10/10.** Rate any domain model 0-10 against the principles below. A 10/10 means full alignment with all guidelines; lower scores indicate gaps. Report the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score a domain model by awarding **1 point per satisfied row of the Quick Diagnostic** (7 rows) plus up to 3 points for depth: +1 if the Core Domain has a genuinely rich model (not just CRUD), +1 if invariants live inside aggregates rather than in services, +1 if the ubiquitous language is consistent across conversation, code, and tests. Bands: **9-10** = expert-readable names, explicit context boundaries with ACLs, small aggregates, behavior-rich entities, events for cross-aggregate flow, an identified Core Domain; **5-6** = some domain language but leaky boundaries or anemic objects; **<=3** = technical naming, one model for everything, logic scattered in services. Report the score and the specific diagnostic rows failing.
 
 ## Framework
 
@@ -41,7 +41,7 @@ Framework for tackling software complexity by modeling code around the business 
 | Module structure | Organize by domain concept | `shipping/`, `billing/` -- not `controllers/`, `services/` |
 | Code review | Reject technical-only names | Flag `Manager`, `Helper`, `Processor`, `Utils` as naming smells |
 
-See: [references/ubiquitous-language.md](references/ubiquitous-language.md) for glossary maintenance and language evolution practices.
+See: [references/ubiquitous-language.md](references/ubiquitous-language.md) when running modeling sessions or maintaining a glossary -- covers how the language evolves and feeds back into code.
 
 ### 2. Bounded Contexts and Context Mapping
 
@@ -118,7 +118,7 @@ See: [references/domain-events.md](references/domain-events.md) for event naming
 
 **Core concept:** Repositories provide the illusion of an in-memory collection of domain objects, hiding persistence. Factories encapsulate complex creation logic so aggregates are always born in a valid state.
 
-**Why it works:** Domain logic should never depend on how objects are stored or constructed. Repositories hide SQL and ORMs so domain code reads like business logic; factories ensure invariants hold from the moment an aggregate exists.
+**Why it works:** When persistence and assembly details leak into domain code, every storage change ripples through business rules and aggregates can be constructed in half-valid states. Repositories confine SQL/ORM concerns to infrastructure so the domain stays testable in memory; factories make the only path to an aggregate one that enforces its invariants, so an invalid instance is unrepresentable.
 
 **Key insights:**
 - The Repository interface belongs in the domain layer; its implementation belongs in infrastructure
@@ -157,7 +157,7 @@ See: [references/repositories-factories.md](references/repositories-factories.md
 | Team allocation | Best developers on Core Domain | Seniors model underwriting rules; juniors integrate the email service |
 | Code organization | Separate core from generic | `domain/pricing/` (deep model) vs. `infrastructure/email/` (thin adapter) |
 
-See: [references/strategic-design.md](references/strategic-design.md) for subdomain classification and distillation techniques.
+See: [references/strategic-design.md](references/strategic-design.md) when deciding where to invest engineering effort -- subdomain classification and distillation techniques.
 
 ## Common Mistakes
 
@@ -182,15 +182,6 @@ See: [references/strategic-design.md](references/strategic-design.md) for subdom
 | Are domain events used for cross-aggregate communication? | Tight coupling, synchronous chains | Introduce events; let aggregates react asynchronously |
 | Is there an Anti-Corruption Layer at every external integration? | Foreign models pollute your domain | Add a translation layer at each boundary |
 | Have you identified which subdomain is core? | Best talent spread thin | Classify subdomains; focus deep modeling on the Core Domain |
-
-## Reference Files
-
-- [ubiquitous-language.md](references/ubiquitous-language.md): Building a shared language, glossary maintenance, naming in code, language evolution
-- [bounded-contexts.md](references/bounded-contexts.md): Context boundaries, nine mapping patterns, team relationships, integration strategies
-- [building-blocks.md](references/building-blocks.md): Entities, Value Objects, Aggregates, aggregate design rules, consistency boundaries
-- [domain-events.md](references/domain-events.md): Event naming, event sourcing, event-driven architecture, integration events
-- [repositories-factories.md](references/repositories-factories.md): Repository pattern, Factory pattern, Specification pattern, ports and adapters
-- [strategic-design.md](references/strategic-design.md): Core Domain, Generic and Supporting Subdomains, distillation, build vs. buy
 
 ## Further Reading
 

--- a/drive-motivation/SKILL.md
+++ b/drive-motivation/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: drive-motivation
-description: 'Design motivation systems using Autonomy, Mastery, and Purpose (AMP) for products and teams. Use when the user mentions "intrinsic motivation", "gamification isnt working", "team incentives", "autonomy", "mastery", "purpose-driven", "employee engagement", "reward systems", "my team is disengaged", "how do I motivate people", or "rewards arent working". Also trigger when designing onboarding progression, fixing broken gamification, or building team structures that sustain high performance. Covers why carrot-and-stick fails and how to build progress systems. For habit-forming product loops, see hooked-ux. For retention behavior design, see improve-retention.'
+description: 'Design motivation systems using Autonomy, Mastery, and Purpose (AMP) for products and teams. Use when the user mentions "intrinsic motivation", "gamification isnt working", "rewards arent working", "autonomy", "mastery", "purpose-driven", "my team is disengaged", or "how do I motivate people". Also trigger when designing onboarding progression, fixing broken gamification, or building team structures that sustain high performance. Covers why carrot-and-stick fails and how to build progress systems. For habit-forming product loops, see hooked-ux. For retention behavior design, see improve-retention.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Drive Motivation Framework
 
-Design motivation systems for products, teams, and organizations based on the science of what actually motivates humans — replacing carrot-and-stick thinking with intrinsic motivation.
+Design motivation systems for products, teams, and organizations using the science of intrinsic motivation.
 
 ## Core Principle
 
@@ -17,7 +17,13 @@ Design motivation systems for products, teams, and organizations based on the sc
 
 ## Scoring
 
-**Goal: 10/10.** Rate any motivation system (product features, team incentives, gamification, engagement loops) 0-10 against the AMP principles below. A 10/10 supports autonomy, enables mastery, and connects to purpose; lower scores indicate reliance on extrinsic rewards or controlling behaviors. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score any motivation system (product features, team incentives, gamification, engagement loops) against the [Quick Diagnostic](#quick-diagnostic): start at 5, add 1 for each of the first five rows answered "yes," then **subtract 2 if the sixth row is also "yes"** — an "if-then" reward doing the motivating crowds out the rest. Bands:
+
+- **9-10** — autonomy, mastery, and purpose all present; no if-then crowding-out.
+- **5-6** — one pillar carries the system; the other two are weak or extrinsic.
+- **≤3** — relies on rewards, mandates, or controlling behaviors; intrinsic motivation absent.
+
+Always state the current score, which diagnostic rows failed, and the specific fixes to reach 10/10.
 
 ## Motivation 1.0, 2.0, and 3.0
 
@@ -26,8 +32,6 @@ Design motivation systems for products, teams, and organizations based on the sc
 | **1.0** | Humans are biological | Survival drives | Pre-industrial |
 | **2.0** | Humans respond to rewards/punishments | Carrot and stick | Industrial age |
 | **3.0** | Humans seek autonomy, mastery, purpose | Intrinsic motivation | Knowledge economy |
-
-Most organizations still run on Motivation 2.0 — fundamentally broken for modern cognitive work.
 
 ### The Seven Deadly Flaws of Extrinsic Rewards
 
@@ -45,7 +49,7 @@ Most organizations still run on Motivation 2.0 — fundamentally broken for mode
 
 **The boundary:** extrinsic rewards work only for routine, algorithmic tasks with no intrinsic interest. For creative work, complex problem-solving, or long-term engagement, they backfire.
 
-See: [references/extrinsic-rewards.md](references/extrinsic-rewards.md) for the science behind reward failures.
+See [references/extrinsic-rewards.md](references/extrinsic-rewards.md) when a reward or incentive scheme is backfiring — the named studies behind each flaw and a decision rule for when rewards are safe to use.
 
 ## The Three Pillars: Autonomy, Mastery, Purpose
 
@@ -70,9 +74,9 @@ See: [references/extrinsic-rewards.md](references/extrinsic-rewards.md) for the 
 | **Content** | Algorithm-only feed | User-controlled feeds, filters |
 | **Workflow** | Rigid process, feature bloat | Custom automations, show/hide, progressive disclosure |
 
-**Autonomy audit:** can users choose WHAT to do, WHEN to engage, HOW to complete tasks, and their own path through the experience? "You must complete X before Y", unskippable tutorials, and mandatory notifications are violations.
+**Autonomy violations:** "You must complete X before Y", unskippable tutorials, mandatory notifications, and forced single paths through the experience.
 
-See: [references/autonomy.md](references/autonomy.md) for autonomy design patterns.
+See [references/autonomy.md](references/autonomy.md) when designing onboarding, feeds, or workflow controls — full Four T's patterns plus the autonomy audit checklist.
 
 ### 2. Mastery
 
@@ -94,9 +98,9 @@ See: [references/autonomy.md](references/autonomy.md) for autonomy design patter
 | **Difficulty** | Adaptive challenge | Games that adjust to player skill |
 | **Feedback** | Immediate, clear signals | Grammarly real-time writing analysis |
 
-**Mastery audit:** can users see progress over time, get immediate feedback, and find a clear next step? Flat difficulty and punished failure are violations.
+**Mastery violations:** flat difficulty that never adapts, and failure that is punished rather than framed as learning.
 
-See: [references/mastery.md](references/mastery.md) for mastery design patterns and flow state principles.
+See [references/mastery.md](references/mastery.md) when designing progress, difficulty, or feedback systems — flow-state calibration, deliberate practice, and the mastery audit checklist.
 
 ### 3. Purpose
 
@@ -118,9 +122,9 @@ See: [references/mastery.md](references/mastery.md) for mastery design patterns 
 | **Community** | Connect to something bigger | Open source contributions, community goals |
 | **Values** | Align product with beliefs | Ecosia: "Search the web to plant trees" |
 
-**Purpose audit:** does the user know WHY this exists, see their impact on something bigger, and find alignment with their values? Show aggregate impact ("Together, our users have saved 1M hours"), connect individual actions to collective outcomes, and celebrate meaningful milestones over vanity metrics.
+**Purpose prescriptions:** show aggregate impact ("Together, our users have saved 1M hours"), connect individual actions to collective outcomes, and celebrate meaningful milestones over vanity metrics.
 
-See: [references/purpose.md](references/purpose.md) for purpose-driven design patterns.
+See [references/purpose.md](references/purpose.md) when wiring impact, community, or values features — Goals/Words/Policies patterns and the purpose audit checklist.
 
 ## AMP Applied: Product Design
 
@@ -146,7 +150,7 @@ See: [references/purpose.md](references/purpose.md) for purpose-driven design pa
 
 Pay people enough to take money off the table — fair, ideally above-market — then focus on AMP; beyond "enough," more money doesn't increase motivation. Prefer "now-that" rewards (unexpected recognition after the fact: "You hit target! Here's a bonus.") over "if-then" rewards ("If you hit target, you get a bonus"), which create pressure and short-term thinking.
 
-See: [references/applications.md](references/applications.md) for product and team applications.
+See [references/applications.md](references/applications.md) when applying AMP to a concrete gamification, team-management, or compensation design — worked examples and escalation tables.
 
 ## Type I vs. Type X Behavior
 
@@ -157,6 +161,8 @@ See: [references/applications.md](references/applications.md) for product and te
 | Short-term focus, fixed mindset | Long-term focus, growth mindset |
 
 Design products and teams that cultivate Type I behavior: it's made, not born; it doesn't disdain money or recognition; it's renewable; and it promotes well-being.
+
+See [references/type-i.md](references/type-i.md) when shifting a team or user base from Type X to Type I — the full behavioral contrast and conversion tactics. For real-world AMP programs (Atlassian ShipIt, 3M, ROWE, Duolingo, Wikipedia), see [references/case-studies.md](references/case-studies.md).
 
 ## Common Mistakes
 
@@ -181,16 +187,6 @@ Audit any motivation system:
 | Is there immediate feedback? | Can't improve | Add real-time response to actions |
 | Does the user know WHY this matters? | No purpose | Connect to mission, show impact |
 | Are we using "if-then" rewards? | Extrinsic crowding-out | Switch to "now-that" or intrinsic design |
-
-## Reference Files
-
-- [extrinsic-rewards.md](references/extrinsic-rewards.md): The seven flaws, when rewards work and don't
-- [autonomy.md](references/autonomy.md): Four T's, product and team autonomy design
-- [mastery.md](references/mastery.md): Flow state, growth mindset, deliberate practice
-- [purpose.md](references/purpose.md): Purpose-driven design, mission alignment
-- [applications.md](references/applications.md): Product gamification, team management, compensation
-- [type-i.md](references/type-i.md): Type I vs. Type X, cultivating intrinsic motivation
-- [case-studies.md](references/case-studies.md): Atlassian, 3M, Duolingo, ROWE, Wikipedia
 
 ## Further Reading
 

--- a/good-strategy-bad-strategy/SKILL.md
+++ b/good-strategy-bad-strategy/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: good-strategy-bad-strategy
-description: 'Formulate and audit real strategy using Richard Rumelt''s "Good Strategy Bad Strategy": an honest diagnosis, a guiding policy, and coherent action instead of goals, vision, and wishful thinking. Use when the user mentions "good strategy bad strategy", "strategy kernel", "diagnosis guiding policy coherent action", "our strategy is just goals", "strategic planning", "mission vs strategy", "review my strategy", "annual plan", "our strategy is vague", or "is this actually a strategy". Also trigger when auditing a strategy doc or pitch deck for fluff, turning a goal list into real strategy, formulating strategy for a product or company, or finding leverage and proximate objectives. Covers the kernel of strategy, bad-strategy detection, and sources of power. For product positioning, see obviously-awesome. For uncontested markets, see blue-ocean-strategy.'
+description: 'Formulate and audit real strategy using Richard Rumelt''s "Good Strategy Bad Strategy": an honest diagnosis, a guiding policy, and coherent action instead of goals, vision, and wishful thinking. Use when the user mentions "good strategy bad strategy", "strategy kernel", "diagnosis guiding policy coherent action", "our strategy is just goals", "strategic planning", "mission vs strategy", "annual plan", or "is this actually a strategy". Also trigger when auditing a strategy doc or pitch deck for fluff, turning a goal list into real strategy, formulating strategy for a product or company, or finding leverage and proximate objectives. Covers the kernel of strategy, bad-strategy detection, and sources of power. For product positioning, see obviously-awesome. For uncontested markets, see blue-ocean-strategy.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Good Strategy Bad Strategy
@@ -17,13 +17,13 @@ A framework for creating and auditing strategy, distilled from Richard Rumelt's 
 
 ## Scoring
 
-**Goal: 10/10.** Rate strategies, plans, and strategy documents 0-10 against the principles below. Report the current score and the specific changes needed to reach 10/10.
+**Goal: 10/10.** Score strategies, plans, and strategy documents by walking the eight rows of the Quick Diagnostic and counting how many pass. Report the current score and the specific changes needed to reach 10/10. The bands below name what each tier looks like; the row count keeps the rating reproducible run to run.
 
-- **9-10:** Complete kernel — honest diagnosis, choiceful guiding policy, coordinated resource-backed actions — aimed at a pivot point, with an explicit list of what will not be done
-- **7-8:** Kernel present but one element weak: thin diagnosis, a policy that rules little out, or actions not yet coordinated and funded
-- **5-6:** The challenge is named, but the plan is a list of independent initiatives and some goals masquerade as strategy
-- **3-4:** Mostly goals, targets, and vision statements; no diagnosis; fluff in key passages; nothing ruled out
-- **0-2:** Pure bad strategy — buzzword fluff, dog's-dinner objective lists, denial of the real challenge
+- **9-10 (8 rows pass):** Complete kernel — honest diagnosis, choiceful guiding policy, coordinated resource-backed actions — aimed at a pivot point, with an explicit list of what will not be done
+- **7-8 (6-7 pass):** Kernel present but one element weak: thin diagnosis, a policy that rules little out, or actions not yet coordinated and funded
+- **5-6 (4-5 pass):** The challenge is named, but the plan is a list of independent initiatives and some goals masquerade as strategy
+- **3-4 (2-3 pass):** Mostly goals, targets, and vision statements; no diagnosis; fluff in key passages; nothing ruled out
+- **0-2 (0-1 pass):** Pure bad strategy — buzzword fluff, dog's-dinner objective lists, denial of the real challenge
 
 ## Framework
 
@@ -51,7 +51,7 @@ A framework for creating and auditing strategy, distilled from Richard Rumelt's 
 
 **Ethical boundary:** An honest diagnosis names internal causes too — never soften it to protect egos or settle politics.
 
-See: [references/kernel.md](references/kernel.md)
+See [references/kernel.md](references/kernel.md) when you actually draft a kernel — diagnosis craft, guiding-policy formulation, coherent-action design, a fill-in template, and two worked examples with owners and done-tests.
 
 ### 2. Detecting Bad Strategy
 
@@ -75,9 +75,7 @@ See: [references/kernel.md](references/kernel.md)
 | OKR review | Separate ambitions from mechanisms | "Double signups" kept as goal, paired with an explicit how |
 | Board update | Demand the challenge slide | "What we're up against" before "what we'll achieve" |
 
-**Ethical boundary:** Audit the document, not the people — bad strategy is usually a process failure, not bad faith.
-
-See: [references/bad-strategy.md](references/bad-strategy.md)
+See [references/bad-strategy.md](references/bad-strategy.md) when auditing a deck or plan — per-hallmark detection checklists, before/after rewrites, why bad strategy proliferates, and a step-by-step deck-audit procedure with a report format.
 
 ### 3. Sources of Power
 
@@ -103,7 +101,7 @@ See: [references/bad-strategy.md](references/bad-strategy.md)
 
 **Ethical boundary:** Build isolating mechanisms on delivered value — lock-in engineered purely to trap users eventually isolates you from them.
 
-See: [references/sources-of-power.md](references/sources-of-power.md)
+See [references/sources-of-power.md](references/sources-of-power.md) when choosing where to apply strength — leverage, proximate objectives, chain-link systems, design, focus, and advantage, each with a when-to-use test (unlock test, addressability test, coherence check).
 
 ### 4. Riding Dynamics and Fighting Inertia
 
@@ -128,7 +126,7 @@ See: [references/sources-of-power.md](references/sources-of-power.md)
 
 **Ethical boundary:** Ride waves by serving the new need better — never by manufacturing fear about the old one.
 
-See: [references/dynamics-inertia.md](references/dynamics-inertia.md)
+See [references/dynamics-inertia.md](references/dynamics-inertia.md) when a market is shifting or an incumbent is stuck — guideposts for spotting waves, diagnosing the three inertia types and entropy, and attacker playbooks for exploiting a rival's inertia.
 
 ### 5. Thinking Like a Strategist
 
@@ -154,7 +152,7 @@ See: [references/dynamics-inertia.md](references/dynamics-inertia.md)
 
 **Ethical boundary:** Use the virtual panel to find flaws, not to stage imagined authority blessing a foregone conclusion.
 
-See: [references/case-studies.md](references/case-studies.md)
+See [references/case-studies.md](references/case-studies.md) for fully worked end-to-end examples — a SaaS annual-plan audit, a startup concentration decision, and a vision deck rewritten into a kernel.
 
 ## Common Mistakes
 
@@ -182,14 +180,6 @@ See: [references/case-studies.md](references/case-studies.md)
 | Does the plan exploit a wave, asymmetry, or rival's inertia? | Strength is matched against strength | Find leverage: anticipation, pivot point, concentration |
 | Is there an explicit list of what you will not do? | Scope creeps back to everything | Write the no-list next to the action list |
 | Has anyone tried to destroy this strategy before adopting it? | First conclusions ship untested | Run create-destroy with a virtual panel of experts |
-
-## Reference Files
-
-- [references/kernel.md](references/kernel.md) — Writing a kernel: diagnosis craft, guiding-policy formulation, coherent-action design, a full template, two worked examples
-- [references/bad-strategy.md](references/bad-strategy.md) — Detection checklists for the four hallmarks, before/after rewrites, why bad strategy proliferates, deck-audit procedure
-- [references/sources-of-power.md](references/sources-of-power.md) — Leverage, proximate objectives, chain-link systems, design, focus, and advantage, with when-to-use guidance
-- [references/dynamics-inertia.md](references/dynamics-inertia.md) — Guideposts for spotting waves of change, diagnosing inertia types and entropy, attacker playbooks
-- [references/case-studies.md](references/case-studies.md) — Three scenarios: a SaaS annual plan audit, a startup concentration decision, a vision deck rewritten into a kernel
 
 ## Further Reading
 

--- a/high-output-management/SKILL.md
+++ b/high-output-management/SKILL.md
@@ -4,7 +4,7 @@ description: 'Manage for output using Grove''s "High Output Management": a manag
 license: MIT
 metadata:
   author: wondelai
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # High Output Management
@@ -48,9 +48,9 @@ Manage teams the way Andy Grove ran Intel: a manager's output is not what the ma
 | Quality gates | Inspect at the lowest-value stage | Spec review kills a flawed design before a three-week build |
 | Hiring pipeline | Batch and build to forecast | Phone screens batched Tue/Thu; interviewer capacity staffed to the offer-date forecast |
 
-**Ethical boundary:** Production thinking applies to the work, never to people as interchangeable machines — run systems hot, not humans.
+**Ethical boundary:** Run systems hot, not humans — production thinking optimizes the work, never treats people as interchangeable machines.
 
-See: [references/indicators-and-production.md](references/indicators-and-production.md)
+See: [references/indicators-and-production.md](references/indicators-and-production.md) when finding a limiting step or building a dashboard — limiting-step analysis, worked indicator pairs, leading vs trend indicators, stagger charts, and how to run an operation review.
 
 ### 2. Indicators That Don't Lie
 
@@ -99,7 +99,7 @@ See: [references/indicators-and-production.md](references/indicators-and-product
 
 **Ethical boundary:** Leverage means multiplying others' output, never hoarding information or approvals until you become the bottleneck everyone must visit.
 
-See: [references/leverage-and-calendar.md](references/leverage-and-calendar.md)
+See: [references/leverage-and-calendar.md](references/leverage-and-calendar.md) when auditing a calendar or setting up delegation — the weekly leverage audit, positive/negative-leverage catalog, delegation protocol with TRM-based monitoring depth, calendar-redesign procedure, and interruption management.
 
 ### 4. Meetings Are the Medium of Management
 
@@ -125,7 +125,7 @@ See: [references/leverage-and-calendar.md](references/leverage-and-calendar.md)
 
 **Ethical boundary:** Hijacking the 1:1 for status extraction teaches people to stop bringing real problems — status belongs in writing.
 
-See: [references/meetings-and-one-on-ones.md](references/meetings-and-one-on-ones.md)
+See: [references/meetings-and-one-on-ones.md](references/meetings-and-one-on-ones.md) when designing a meeting cadence or running a 1:1 — the full 1:1 playbook with agenda templates, staff-meeting design, operation-review roles, and meeting-cost math for when to kill a meeting.
 
 ### 5. Decisions and Planning (incl. OKRs)
 
@@ -149,15 +149,13 @@ See: [references/meetings-and-one-on-ones.md](references/meetings-and-one-on-one
 | Decision prep | Six-question brief | "Pick payments vendor by Jun 30; platform PM decides; eng and finance consulted; VP ratifies" |
 | Quarterly planning | Cascading OKRs | Company KR "checkout p95 under 800ms" becomes the platform team's objective |
 
-**Ethical boundary:** Disagree-and-commit is legitimate only when the disagreement was genuinely heard; commitment extracted without discussion is mere compliance.
-
-See: [references/decisions-planning-okrs.md](references/decisions-planning-okrs.md)
+See: [references/decisions-planning-okrs.md](references/decisions-planning-okrs.md) when prepping a contentious decision or a planning cycle — the six-question brief, peer-group-syndrome counters, three-step planning, and a Grove-style OKR cascade with pitfalls.
 
 ### 6. Task-Relevant Maturity, Reviews, and Training
 
 **Core concept:** There is no universally good management style. The right style depends on the subordinate's task-relevant maturity (TRM) — their experience, training, and confidence for this specific task: low TRM calls for structured "how" instruction, medium for mutual reasoning about "what and why", high for agreed objectives with light monitoring. TRM is task-specific, not seniority, so style must shift the moment the task does.
 
-**Why it works:** Mismatched style fails in both directions — hands-off at low TRM is abandonment dressed as empowerment; detailed instruction at high TRM is meddling that destroys ownership. Matching style to TRM is what makes delegation safe and growth fast, and the performance review is the most consequential place to apply it.
+**Why it works:** Mismatched style fails in both directions — hands-off at low TRM is abandonment dressed as empowerment; detailed instruction at high TRM is meddling that destroys ownership. The performance review is where the cost of a mismatch compounds: a year's feedback delivered in the wrong register lands as either neglect or insult.
 
 **Key insights:**
 - A star promoted into management is high-TRM on engineering and low-TRM on managing — structure the new task even for your best person
@@ -175,9 +173,7 @@ See: [references/decisions-planning-okrs.md](references/decisions-planning-okrs.
 | Review prep | Assess first, message second | Full written assessment, then the three messages that change next year |
 | Team capability | Manager-taught training | EM personally teaches a four-session incident-response course |
 
-**Ethical boundary:** Reviews exist to develop people, not to punish them — and matching style to TRM is coaching, not condescension.
-
-See: [references/case-studies.md](references/case-studies.md)
+See: [references/case-studies.md](references/case-studies.md) when preparing a review or coaching a newly promoted manager — three worked scenarios (meeting-drowned new manager, velocity-up/quality-down, a botched review repaired with TRM coaching).
 
 ## Common Mistakes
 
@@ -204,14 +200,6 @@ See: [references/case-studies.md](references/case-studies.md)
 | Was your last big decision made at the lowest competent level? | Rank decided; knowledge watched | Name decider, consulted, and ratifier before the meeting |
 | Would your team set the same OKRs if pay weren't attached? | Objectives are sandbagged | Decouple OKRs from the compensation formula |
 | Have you personally taught your team anything this quarter? | Highest-leverage activity skipped | Schedule a manager-taught course now |
-
-## Reference Files
-
-- [references/leverage-and-calendar.md](references/leverage-and-calendar.md) — Weekly leverage audit, positive/negative leverage catalog, delegation protocol with TRM-based monitoring depth, calendar redesign procedure, interruption management
-- [references/indicators-and-production.md](references/indicators-and-production.md) — Limiting step analysis, pairing indicators with worked examples, leading vs trend indicators, stagger charts, running an operation review
-- [references/meetings-and-one-on-ones.md](references/meetings-and-one-on-ones.md) — Full 1:1 playbook with agenda templates, staff meeting design, operation review roles, meeting-cost math and when to kill a meeting
-- [references/decisions-planning-okrs.md](references/decisions-planning-okrs.md) — Decision protocol and six-question brief, peer-group syndrome counters, three-step planning, Grove-style OKR cascade with pitfalls
-- [references/case-studies.md](references/case-studies.md) — Three scenarios: a meeting-drowned new manager, velocity-up-quality-down fixed with pairing indicators, a botched review repaired with TRM coaching
 
 ## Further Reading
 

--- a/high-perf-browser/SKILL.md
+++ b/high-perf-browser/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: high-perf-browser
-description: 'Optimize web performance through network protocols, resource loading, and browser rendering internals. Use when the user mentions "page load speed", "Core Web Vitals", "HTTP/2", "resource hints", "network latency", "render blocking", "TCP optimization", "service worker", "critical rendering path", "my site is slow", "improve page speed", or "slow to load". Also trigger when diagnosing slow page loads, optimizing time to first byte, choosing between WebSocket and SSE, or reducing bundle sizes. Covers TCP/TLS optimization, caching strategies, WebSocket/SSE, and protocol selection. For UI visual performance, see refactoring-ui. For font loading, see web-typography.'
+description: 'Optimize web performance through network protocols, resource loading, and browser rendering internals. Use when the user mentions "my site is slow", "Core Web Vitals", "HTTP/2 or HTTP/3", "resource hints", "network latency", "render blocking", "TCP/TLS optimization", "service worker", "Cache-Control or caching strategy", or "critical rendering path". Also trigger when diagnosing slow page loads, optimizing time to first byte, choosing between WebSocket and SSE, or reducing bundle sizes. For UI visual performance, see refactoring-ui. For font loading, see web-typography.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # High Performance Browser Networking Framework
@@ -19,7 +19,7 @@ A systematic approach to web performance grounded in how browsers, protocols, an
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or building web applications, rate performance 0-10 based on adherence to the principles below. A 10/10 means full alignment with all guidelines; lower scores indicate gaps to address. Always provide the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score by how many of the eight Quick Diagnostic rows pass, weighted toward the field metrics: **9-10** = all eight pass (the four field-metric rows in the green plus content-hashing, HTTP/2+, minimized render-blocking, and compression); **5-6** = the four field-metric rows pass but one or more transport/caching/compression rows fail; **<=3** = any field-metric row is in the red. Always report the score, which diagnostic rows failed, and the specific fix for each.
 
 ## The High Performance Browser Networking Framework
 
@@ -34,7 +34,7 @@ Six domains for building fast, resilient web applications:
 **Key insights:**
 - TCP three-way handshake adds one full RTT before data transfer begins
 - TCP slow start limits initial throughput to ~14KB (10 segments) in the first round trip — keep critical resources under this threshold
-- TLS 1.2 adds 2 RTTs; TLS 1.3 reduces this to 1 RTT (0-RTT with session resumption)
+- Upgrade to TLS 1.3: it halves the handshake round trips of TLS 1.2 and enables 0-RTT resumption for returning visitors
 - Head-of-line blocking in TCP means one lost packet stalls all streams on that connection
 - Bandwidth-delay product caps in-flight data; high-latency links underutilize bandwidth
 
@@ -47,7 +47,7 @@ Six domains for building fast, resilient web applications:
 | **TLS optimization** | TLS 1.3 + session resumption | `ssl_protocols TLSv1.3;` with session tickets |
 | **Connection reuse** | Keep-alive avoids repeated handshakes | `Connection: keep-alive` (default in HTTP/1.1+) |
 
-See: [references/network-fundamentals.md](references/network-fundamentals.md) for TCP congestion control, bandwidth-delay product, and TLS handshake details.
+See [references/network-fundamentals.md](references/network-fundamentals.md) when tuning servers or diagnosing handshake latency — the full TLS 1.2-vs-1.3 RTT derivation, slow-start doubling table, initcwnd/BDP math, OCSP-stapling Nginx config, and the DNS cache hierarchy.
 
 ### 2. HTTP Protocol Evolution
 
@@ -72,7 +72,7 @@ See: [references/network-fundamentals.md](references/network-fundamentals.md) fo
 | **QUIC/HTTP/3** | Advertise HTTP/3 on CDN or origin | `Alt-Svc: h3=":443"` header |
 | **Stream prioritization** | Signal resource importance | CSS and fonts highest priority; images lower |
 
-See: [references/http-protocols.md](references/http-protocols.md) for protocol comparison, migration strategies, and server push vs. Early Hints.
+See [references/http-protocols.md](references/http-protocols.md) when picking or migrating a protocol version — side-by-side HTTP/1.1-vs-2-vs-3 comparison, the step-by-step de-sharding migration, and why Server Push lost to 103 Early Hints.
 
 ### 3. Resource Loading and Critical Rendering Path
 
@@ -95,7 +95,7 @@ See: [references/http-protocols.md](references/http-protocols.md) for protocol c
 | **Resource hints** | Preload critical fonts, hero images | `<link rel="preload" href="font.woff2" as="font" crossorigin>` |
 | **Image optimization** | Lazy-load below-fold; modern formats | `<img loading="lazy" src="photo.avif" srcset="...">` |
 
-See: [references/resource-loading.md](references/resource-loading.md) for async/defer behavior, resource hint strategies, and image and font optimization.
+See [references/resource-loading.md](references/resource-loading.md) when shaving first paint — the exact async/defer/module execution order, the full resource-hint decision tree, and the image/font (`font-display`, `srcset`, AVIF) playbook.
 
 ### 4. Caching Strategies
 
@@ -118,19 +118,19 @@ See: [references/resource-loading.md](references/resource-loading.md) for async/
 | **API responses** | Short TTL + background refresh | `Cache-Control: max-age=60, stale-while-revalidate=3600` |
 | **CDN config** | Cache at edge with correct Vary | `Vary: Accept-Encoding, Accept` |
 
-See: [references/caching-strategies.md](references/caching-strategies.md) for cache hierarchy, service worker patterns, and CDN configuration.
+See [references/caching-strategies.md](references/caching-strategies.md) when designing a cache policy — the full browser/SW/CDN/origin hierarchy, copy-paste service-worker cache-first vs network-first recipes, and the `Vary` pitfalls that pollute a CDN.
 
 ### 5. Core Web Vitals Optimization
 
 **Core concept:** Core Web Vitals — LCP, INP, CLS — are Google's user-centric metrics covering loading, interactivity, and visual stability. They impact search ranking and reflect real user experience.
 
-**Why it works:** These metrics measure what users perceive, not what servers report: a fast TTFB means nothing if the hero image loads late (LCP) or main-thread JavaScript blocks input (INP). Optimizing for them is optimizing for real perception.
+**Why it works:** A fast TTFB means nothing if the hero image still loads late (LCP) or main-thread JavaScript blocks the first input (INP) — so server-side timing can look green while users wait. Optimize the perceived milestones, not the byte-delivery clock.
 
-**Key insights (targets):**
-- LCP < 2.5s — optimize the largest visible element (hero image, heading block, video poster)
-- INP < 200ms — keep the main thread free; break long tasks
-- CLS < 0.1 — reserve space for dynamic content before it loads
-- TTFB < 800ms and FCP < 1.8s feed everything downstream
+**Key insights** (numeric pass/fail thresholds live in the Quick Diagnostic):
+- LCP — optimize the largest visible element (hero image, heading block, video poster)
+- INP — keep the main thread free; break long tasks so input is never blocked
+- CLS — reserve space for dynamic content before it loads
+- TTFB and FCP (< 1.8s) are upstream gates: they bound every downstream milestone, so fix them first
 - Measure with Real User Monitoring (RUM) in production — lab/synthetic tests miss real-device and network variance
 
 **Code applications:**
@@ -140,9 +140,9 @@ See: [references/caching-strategies.md](references/caching-strategies.md) for ca
 | **LCP** | Preload LCP element; raise its priority | `<img src="hero.webp" fetchpriority="high">` |
 | **INP** | Break long tasks; yield to main thread | `scheduler.yield()` or `setTimeout` chunking |
 | **CLS** | Reserve space for async content | `<img width="800" height="600">` or CSS `aspect-ratio` |
-| **Performance budget** | Block deploys that exceed thresholds | LCP < 2.5s, INP < 200ms, CLS < 0.1 in CI |
+| **Performance budget** | Fail CI when a vital regresses past its Quick Diagnostic threshold | Lighthouse CI assertions on LCP/INP/CLS |
 
-See: [references/core-web-vitals.md](references/core-web-vitals.md) for measurement tools, debugging workflows, and optimization checklists.
+See [references/core-web-vitals.md](references/core-web-vitals.md) when a metric is in the red — per-metric debugging workflows (what to inspect for a bad LCP/INP/CLS), the lab-vs-RUM tooling map, and per-vital optimization checklists.
 
 ### 6. Real-Time Communication
 
@@ -166,7 +166,7 @@ See: [references/core-web-vitals.md](references/core-web-vitals.md) for measurem
 | **Connection resilience** | Exponential backoff on reconnect | 1s, 2s, 4s, 8s... capped at 30s |
 | **Scaling** | Pub/sub broker behind WebSocket servers | Redis Pub/Sub or NATS |
 
-See: [references/real-time-communication.md](references/real-time-communication.md) for WebSocket lifecycle, SSE patterns, and scaling strategies.
+See [references/real-time-communication.md](references/real-time-communication.md) when building a live feature — the WebSocket connect/heartbeat/reconnect lifecycle, the SSE `EventSource` pattern, and how to scale fan-out behind a pub/sub broker.
 
 ## Common Mistakes
 
@@ -193,15 +193,6 @@ See: [references/real-time-communication.md](references/real-time-communication.
 | Is HTTP/2 or HTTP/3 enabled? | No multiplexing or header compression | Enable HTTP/2 on server; HTTP/3 via CDN |
 | Are render-blocking resources minimized? | CSS and sync JS delay first paint | Inline critical CSS; `defer` scripts; prune unused CSS |
 | Is compression enabled (Brotli/Gzip)? | Uncompressed text transfers | Enable Brotli on server/CDN; Gzip fallback |
-
-## Reference Files
-
-- [network-fundamentals.md](references/network-fundamentals.md): TCP handshake, congestion control, TLS optimization, DNS resolution, head-of-line blocking
-- [http-protocols.md](references/http-protocols.md): HTTP/1.1 workarounds, HTTP/2 multiplexing, HTTP/3 and QUIC, migration strategies
-- [resource-loading.md](references/resource-loading.md): Critical rendering path, async/defer, resource hints, image and font optimization
-- [caching-strategies.md](references/caching-strategies.md): Cache-Control headers, service workers, CDN configuration, cache invalidation
-- [core-web-vitals.md](references/core-web-vitals.md): LCP, INP, CLS optimization, measurement tools, performance budgets
-- [real-time-communication.md](references/real-time-communication.md): WebSocket, SSE, long polling, connection management, scaling
 
 ## Further Reading
 

--- a/high-perf-browser/SKILL.md
+++ b/high-perf-browser/SKILL.md
@@ -4,7 +4,7 @@ description: 'Optimize web performance through network protocols, resource loadi
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # High Performance Browser Networking Framework
@@ -124,11 +124,11 @@ See [references/caching-strategies.md](references/caching-strategies.md) when de
 
 **Core concept:** Core Web Vitals — LCP, INP, CLS — are Google's user-centric metrics covering loading, interactivity, and visual stability. They impact search ranking and reflect real user experience.
 
-**Why it works:** A fast TTFB means nothing if the hero image still loads late (LCP) or main-thread JavaScript blocks the first input (INP) — so server-side timing can look green while users wait. Optimize the perceived milestones, not the byte-delivery clock.
+**Why it works:** A fast TTFB means nothing if the hero image still loads late (LCP) or main-thread JavaScript blocks interactions (INP) — so server-side timing can look green while users wait. Optimize the perceived milestones, not the byte-delivery clock.
 
 **Key insights** (numeric pass/fail thresholds live in the Quick Diagnostic):
 - LCP — optimize the largest visible element (hero image, heading block, video poster)
-- INP — keep the main thread free; break long tasks so input is never blocked
+- INP — keep the main thread free; break long tasks so every interaction (not only the first) stays responsive
 - CLS — reserve space for dynamic content before it loads
 - TTFB and FCP (< 1.8s) are upstream gates: they bound every downstream milestone, so fix them first
 - Measure with Real User Monitoring (RUM) in production — lab/synthetic tests miss real-device and network variance

--- a/high-perf-browser/references/core-web-vitals.md
+++ b/high-perf-browser/references/core-web-vitals.md
@@ -103,7 +103,7 @@ Fixes:
 
 INP measures the delay between a user interaction (click, tap, keypress) and the next visual update. It replaced FID (First Input Delay) as a Core Web Vital in March 2024.
 
-**Why INP matters more than FID:** FID only measured the delay of the first interaction. INP measures all interactions throughout the page lifecycle and reports the worst (at the 98th percentile). A page can have a good FID but terrible INP if JavaScript blocks the main thread during later interactions.
+**Why INP matters more than FID:** FID only measured the delay of the first interaction. INP measures all interactions throughout the page lifecycle and reports the single worst one — except on pages with many interactions, where it drops roughly one outlier per 50 interactions (approximating the 98th percentile for high-interaction pages). A page can have a good FID but terrible INP if JavaScript blocks the main thread during later interactions.
 
 ### What causes poor INP
 

--- a/hooked-ux/SKILL.md
+++ b/hooked-ux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: hooked-ux
-description: 'Design habit-forming product loops using the Hook Model (Trigger, Action, Variable Reward, Investment). Use when the user mentions "users arent coming back", "engagement loops", "habit formation", "push notifications", "variable rewards", "daily active users", "habit zone", "user retention loops", "build a habit", "increase engagement", or "how do I get users to return". Also trigger when designing notification strategies, building streaks or progress systems, or analyzing why users stop after signup. Covers ethics evaluation and onboarding for habits. For friction reduction and B=MAP, see improve-retention. For viral sharing, see contagious.'
+description: 'Design habit-forming product loops using the Hook Model (Trigger, Action, Variable Reward, Investment). Use when the user mentions "users arent coming back", "habit formation", "engagement loops", "habit zone", or "the manipulation matrix". Also trigger when designing notification or re-engagement strategies, building streaks or progress systems, or analyzing why users stop after signup. Covers ethics evaluation and onboarding for habits. For friction reduction and B=MAP, see improve-retention. For viral sharing, see contagious.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Hook Model Framework
@@ -23,7 +23,7 @@ Trigger → Action → Variable Reward → Investment
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating product engagement mechanics, rate them 0-10 based on adherence to the principles below. A 10/10 means full alignment with all guidelines; lower scores indicate gaps to address. Always provide the current score and specific improvements needed to reach 10/10.
+**Goal: 10/10.** When reviewing or creating product engagement mechanics, score the loop by the four Quick Diagnostic rows (internal trigger, dead-simple action, variable reward, investment loads next trigger): award 2 points per row fully satisfied, 1 if partial, 0 if absent. Then apply the ethics gate: if the Manipulation Matrix places the product as Dealer (or it hits any "When NOT to Use" condition), cap the score at 3 regardless of mechanics. Bands: 9-10 = complete loop, internal trigger identified, ethics clear; 5-6 = loop runs but leans on external triggers or predictable rewards; <=3 = broken loop or extractive design. Always state the current score and the specific diagnostic rows blocking 10/10.
 
 ## The Four Phases
 
@@ -31,7 +31,7 @@ Trigger → Action → Variable Reward → Investment
 
 **Core concept:** The actuator of behavior. Triggers are external (environment-driven: notifications, emails, ads) or internal (emotion-driven) — and the goal is to migrate users from external to internal triggers.
 
-**Why it works:** Every habit starts with a cue. External triggers get users started, but internal triggers — boredom, loneliness, uncertainty, FOMO — drive unprompted usage; when your product becomes the automatic response to an emotion, you have a habit.
+**Why it works:** Every habit starts with a cue. External triggers get users started, but internal triggers — boredom, loneliness, uncertainty, FOMO — drive unprompted usage because the emotion itself fires before any reminder can.
 
 **Key insights:**
 - Map your product to the specific negative emotion it resolves (boredom, loneliness, confusion, FOMO)
@@ -51,9 +51,9 @@ Trigger → Action → Variable Reward → Investment
 - "Your friend just..." (social trigger bridging to internal)
 - "Pick up where you left off" (routine trigger)
 
-**Ethical boundary:** Never exploit vulnerable emotional states (depression, addiction, grief) — triggers should connect users to genuine value, not manufacture anxiety to drive opens.
+**Ethical boundary:** Don't build triggers that fire on vulnerable emotional states (depression, addiction, grief) — those users can't exercise the autonomy the loop assumes.
 
-See: [references/triggers.md](references/triggers.md) for trigger design, emotion mapping, and external-to-internal transition strategies.
+See [references/triggers.md](references/triggers.md) when mapping triggers — the emotion-to-product mapping exercise and the external-to-internal transition plan.
 
 ### 2. Action
 
@@ -79,9 +79,9 @@ See: [references/triggers.md](references/triggers.md) for trigger design, emotio
 - "No credit card required" (money/risk simplicity)
 - Buttons should be verbs: "Post", "Save", "Share" — not "Submit" or "Continue"
 
-**Ethical boundary:** Reduce friction on genuinely valuable actions only — dark patterns that hide costs or consequences behind simple actions are unethical.
+**Ethical boundary:** When you simplify an action, don't strip the cost or consequence with it — a one-tap purchase must still surface the price and the commitment.
 
-See: [references/product-applications.md](references/product-applications.md) for action and investment design across product types.
+See [references/product-applications.md](references/product-applications.md) when adapting the loop to your context — action and investment patterns for B2B SaaS, e-commerce, health, and productivity tools.
 
 ### 3. Variable Reward
 
@@ -109,7 +109,7 @@ See: [references/product-applications.md](references/product-applications.md) fo
 
 **Ethical boundary:** If users consistently feel worse after engaging (regret, time loss, anxiety), the reward system is extractive — avoid infinite scroll without natural stopping points.
 
-See: [references/rewards.md](references/rewards.md) for reward design patterns, reinforcement schedules, and reward timing.
+See [references/rewards.md](references/rewards.md) when designing a reward — tribe/hunt/self patterns, the four reinforcement schedules, and reward timing. For the dopamine/anticipation mechanism behind variable rewards, see [references/neuroscience-foundations.md](references/neuroscience-foundations.md).
 
 ### 4. Investment
 
@@ -157,7 +157,7 @@ The 5% rule: a habit has formed when at least 5% of users show unprompted, habit
 2. **What are they doing?** Identify the "Habit Path" — the action sequence that separates power users from casual users.
 3. **Why are they doing it?** What internal trigger and emotion precede usage?
 
-See: [references/habit-testing.md](references/habit-testing.md) for testing methodology.
+See [references/habit-testing.md](references/habit-testing.md) when running the test — cohort analysis, finding the Habit Path, and confirming the 5% threshold. For worked teardowns of these loops in real products (Instagram, Slack, Duolingo, Pinterest, and failures), see [references/case-studies.md](references/case-studies.md).
 
 ## The Manipulation Matrix
 
@@ -177,7 +177,7 @@ Ask: would I use this myself? Does it genuinely help users achieve their goals? 
 - The business model depends on user regret
 - Engagement conflicts with user wellbeing
 
-See: [references/ethical-boundaries.md](references/ethical-boundaries.md) for comprehensive ethics guidance.
+See [references/ethical-boundaries.md](references/ethical-boundaries.md) when the Manipulation Matrix flags a concern — dark-pattern catalog and how to protect vulnerable users.
 
 ### Regulatory Context
 
@@ -227,16 +227,6 @@ Audit any product feature:
 | Is the action dead simple? | Users start but don't complete | Remove friction |
 | Is the reward variable? | Users get bored | Add unpredictability |
 | Does investment load next trigger? | Users don't return | Connect investment to triggers |
-
-## Reference Files
-
-- [triggers.md](references/triggers.md): External and internal trigger design, emotion mapping
-- [rewards.md](references/rewards.md): Variable reward types, reinforcement schedules, reward timing
-- [habit-testing.md](references/habit-testing.md): Testing methodology, habit zone identification
-- [case-studies.md](references/case-studies.md): Instagram, Slack, Duolingo, Pinterest, and failed products analysis
-- [ethical-boundaries.md](references/ethical-boundaries.md): Dark patterns vs. ethical engagement, protecting vulnerable users
-- [neuroscience-foundations.md](references/neuroscience-foundations.md): Dopamine, variable reinforcement schedules, habit loop neuroscience
-- [product-applications.md](references/product-applications.md): B2B SaaS, e-commerce, health apps, productivity tools patterns
 
 ## Further Reading
 

--- a/hooked-ux/SKILL.md
+++ b/hooked-ux/SKILL.md
@@ -4,7 +4,7 @@ description: 'Design habit-forming product loops using the Hook Model (Trigger, 
 license: MIT
 metadata:
   author: wondelai
-  version: "1.5.0"
+  version: "1.5.1"
 ---
 
 # Hook Model Framework
@@ -23,7 +23,7 @@ Trigger → Action → Variable Reward → Investment
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating product engagement mechanics, score the loop by the four Quick Diagnostic rows (internal trigger, dead-simple action, variable reward, investment loads next trigger): award 2 points per row fully satisfied, 1 if partial, 0 if absent. Then apply the ethics gate: if the Manipulation Matrix places the product as Dealer (or it hits any "When NOT to Use" condition), cap the score at 3 regardless of mechanics. Bands: 9-10 = complete loop, internal trigger identified, ethics clear; 5-6 = loop runs but leans on external triggers or predictable rewards; <=3 = broken loop or extractive design. Always state the current score and the specific diagnostic rows blocking 10/10.
+**Goal: 10/10.** When reviewing or creating product engagement mechanics, score the loop by the four Quick Diagnostic rows (internal trigger, dead-simple action, variable reward, investment loads next trigger): each row earns 2 (fully satisfied), 1 (partial), or 0 (absent), then `score = round(total / 8 × 10)`. Then apply the ethics gate: if the Manipulation Matrix places the product as Dealer (or it hits any "When NOT to Use" condition), cap the score at 3 regardless of mechanics. Bands: 9-10 = complete loop, internal trigger identified, ethics clear; 5-6 = loop runs but leans on external triggers or predictable rewards; <=3 = broken loop or extractive design. Always state the current score and the specific diagnostic rows blocking 10/10.
 
 ## The Four Phases
 

--- a/hundred-million-offers/SKILL.md
+++ b/hundred-million-offers/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: hundred-million-offers
-description: 'Create irresistible offers using the Value Equation, bonus stacking, risk-reversing guarantees, and ethical scarcity. Use when the user mentions "irresistible offer", "bonuses and guarantees", "value-to-price ratio", "offer naming", "grand slam offer", "guarantee strategy", "premium pricing justification", "make my offer more compelling", "what bonuses should I add", "stop discounting", or "people say its too expensive". Also trigger when packaging a product for higher perceived value, designing a money-back guarantee, or structuring tiers to maximize conversions. Covers the MAGIC naming formula and starving-crowd targeting. For product positioning, see obviously-awesome. For outbound sales, see predictable-revenue.'
+description: 'Create irresistible offers using the Value Equation, bonus stacking, risk-reversing guarantees, and ethical scarcity. Use when the user mentions "grand slam offer", "make my offer more compelling", "what bonuses should I add", "guarantee strategy", "offer naming", or "people say its too expensive". Also trigger when packaging a product for higher perceived value, justifying premium pricing instead of discounting, designing a money-back guarantee, or structuring tiers to maximize conversions. Covers the MAGIC naming formula and starving-crowd targeting. For product positioning, see obviously-awesome. For outbound sales, see predictable-revenue.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Grand Slam Offer Creation Framework
@@ -17,7 +17,7 @@ Framework for creating offers so good people feel stupid saying no. What you sel
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating offers, rate them 0-10 against the principles below. A 10/10 is genuinely irresistible — high perceived value, reversed risk, ethical scarcity, compelling bonuses, and a name that demands attention. Always provide the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score any offer by the 7-row Quick Diagnostic at the end of this file — award ~1.4 points per row answered "yes," rounding to a 0-10 scale. Bands: **9-10** = all/nearly all rows pass (irresistible: 10x perceived value, reversed risk, ethical scarcity, named dollar-valued bonuses, a category-of-one bundle, a MAGIC name); **5-6** = value and market are right but risk, bonuses, or scarcity are missing; **<=3** = a commodity priced on cost with no guarantee or reason to act now. Always report the current score and the specific diagnostic rows that must flip to "yes" to reach 10/10.
 
 ## The Grand Slam Offer Framework
 
@@ -47,9 +47,9 @@ Framework for creating offers so good people feel stupid saying no. What you sel
 - "Guaranteed [result] or [risk reversal]"
 - "We do [hard part] so you don't have to"
 
-**Ethical boundary:** Never promise outcomes you cannot reasonably deliver — substantiate every speed, effort, and results claim with real data or state it as aspirational.
+**Ethical boundary:** Back every speed, effort, and results claim with data, or label it aspirational rather than asserting it.
 
-See: [references/value-equation.md](references/value-equation.md) for the four levers, optimization tactics, and scoring rubric.
+See [references/value-equation.md](references/value-equation.md) when scoring an offer's value: per-lever 1-10 rubric, a composite-score calculator, and lever-interaction effects.
 
 ### 2. The Grand Slam Offer
 
@@ -76,9 +76,9 @@ See: [references/value-equation.md](references/value-equation.md) for the four l
 - "Total value: $[sum of components]. Your investment: $[price]."
 - "Everything you need to [Dream Outcome] in one package"
 
-**Ethical boundary:** Assign honest, defensible dollar values to each component — never inflate values to fake a value-price gap.
+**Ethical boundary:** Price each component at what someone would actually pay for it standalone — never inflate values to fake the value-price gap.
 
-See: [references/grand-slam-offers.md](references/grand-slam-offers.md) for the full offer assembly process and problem-solution mapping.
+See [references/grand-slam-offers.md](references/grand-slam-offers.md) when assembling the full package: problem-solution mapping and the Trim & Stack method worked end to end.
 
 ### 3. Finding Your Starving Crowd
 
@@ -107,7 +107,7 @@ See: [references/grand-slam-offers.md](references/grand-slam-offers.md) for the 
 
 **Ethical boundary:** Target genuine need and fit, never vulnerability — avoid people in crisis who cannot make rational decisions.
 
-See: [references/starving-crowd.md](references/starving-crowd.md) for market selection criteria and the niche scorecard.
+See [references/starving-crowd.md](references/starving-crowd.md) when choosing or validating a market: the four-criteria niche scorecard and demand-validation checks.
 
 ### 4. Value-Based Pricing
 
@@ -135,15 +135,13 @@ See: [references/starving-crowd.md](references/starving-crowd.md) for market sel
 - "The cost of doing nothing is $[opportunity cost] per [time period]"
 - "An investment of $[price] for $[10x value] in [outcome]"
 
-**Ethical boundary:** Substantiate value claims — if you claim 10x ROI, have data, case studies, or a clear logical basis.
-
-See: [references/pricing-strategy.md](references/pricing-strategy.md) for value-based pricing frameworks and anchoring techniques.
+See [references/pricing-strategy.md](references/pricing-strategy.md) when setting a price: value-based pricing frameworks, cost-of-inaction anchoring, and payment-plan structures.
 
 ### 5. Bonuses: Value Stacking
 
 **Core concept:** Bonuses are added components that address remaining objections and make the offer feel like an overwhelming deal — each solving a specific problem with an independently justifiable dollar value.
 
-**Why it works:** When total bonus value exceeds the price, the core product feels "free," and each bonus preemptively removes a reason not to buy.
+**Why it works:** Each bonus is attached to a specific unspoken objection, so the prospect's reasons not to buy are answered before they surface — and once stacked value exceeds the price, the core product reads as "free."
 
 **Key insights:**
 - Each bonus should kill a specific objection or obstacle to success
@@ -164,9 +162,7 @@ See: [references/pricing-strategy.md](references/pricing-strategy.md) for value-
 - "We added this because we noticed [objection] was holding people back"
 - "Total bonus value: $[sum]. Yours free when you join today."
 
-**Ethical boundary:** Every bonus dollar value must be defensible — price it at what someone would actually pay for it on its own.
-
-See: [references/bonuses-stacking.md](references/bonuses-stacking.md) for bonus design frameworks and stacking strategies.
+See [references/bonuses-stacking.md](references/bonuses-stacking.md) when designing bonuses: objection-to-bonus mapping, dollar-value assignment, and stack-order strategy.
 
 ### 6. Guarantees: Reversing Risk
 
@@ -194,15 +190,15 @@ See: [references/bonuses-stacking.md](references/bonuses-stacking.md) for bonus 
 - "Try it for [time period]. If you're not [specific outcome], we'll [reversal]."
 - "You literally cannot lose."
 
-**Ethical boundary:** Honor every guarantee without friction or fine-print traps — a guarantee that's hard to claim destroys trust permanently.
+**Ethical boundary:** Make the guarantee frictionless to claim — no fine-print traps or hoops; a guarantee that's hard to invoke destroys trust permanently.
 
-See: [references/guarantees.md](references/guarantees.md) for the five guarantee types, naming strategies, and stacking approaches.
+See [references/guarantees.md](references/guarantees.md) when choosing or wording a guarantee: the five types compared, naming strategies, and how to stack them.
 
 ### 7. Scarcity and Urgency
 
 **Core concept:** Scarcity limits quantity (how many); urgency limits time (how long). Both give people who already want the offer a reason to act now.
 
-**Why it works:** Without a reason to act now, prospects default to "I'll think about it" — which functionally means no. Loss aversion makes the fear of missing out outweigh the inertia of inaction.
+**Why it works:** Loss aversion makes a looming "you'll miss out" outweigh the inertia of "I'll think about it" — and "I'll think about it" functionally means no.
 
 **Key insights:**
 - Scarcity of supply: limited seats, enrollment caps, production runs; urgency of time: enrollment windows, deadline-driven bonuses
@@ -223,9 +219,9 @@ See: [references/guarantees.md](references/guarantees.md) for the five guarantee
 - "Enrollment closes [specific date] at midnight"
 - "First [X] people to join also receive [bonus]"
 
-**Ethical boundary:** Every scarcity and urgency claim must be 100% true — if you say 20 spots, there are 20 spots; fake scarcity (e.g., resetting countdown timers) is the fastest way to destroy a brand.
+**Ethical boundary:** Every scarcity and urgency claim must be 100% true — if you say 20 spots, there are 20 spots. Never reset a countdown timer or fake a sold-out; it is the fastest way to destroy a brand.
 
-See: [references/scarcity-urgency.md](references/scarcity-urgency.md) for ethical scarcity patterns and evergreen urgency techniques.
+See [references/scarcity-urgency.md](references/scarcity-urgency.md) when adding a reason to act now: ethical scarcity patterns, cohort models, and evergreen urgency tied to real events.
 
 ### 8. Naming the Offer
 
@@ -254,24 +250,26 @@ See: [references/scarcity-urgency.md](references/scarcity-urgency.md) for ethica
 - "[Goal] [Container] for [Avatar]"
 - "[Number]-Day [Goal] [Container] for [Avatar]"
 
-**Ethical boundary:** The name must accurately represent the offer — aspirational is fine, deceptive is not (no "6-Figure Blueprint" if customers don't reach six figures).
+**Ethical boundary:** The name may be aspirational but never deceptive — don't promise an outcome in the name (e.g. "6-Figure Blueprint") that customers don't actually reach.
 
-See: [references/naming-offers.md](references/naming-offers.md) for the MAGIC formula breakdown, 20+ examples, and naming dos and don'ts.
+See [references/naming-offers.md](references/naming-offers.md) when naming or A/B-testing a name: the MAGIC breakdown, container-word tables, 20+ worked examples, and test methods.
 
 ## Offer Creation Process
 
-Follow these 10 steps in order to build a Grand Slam Offer from scratch:
+To build a Grand Slam Offer from scratch, run the eight sections above in this order:
 
-1. **Identify your starving crowd** — score markets on pain, purchasing power, targetability, growth.
-2. **Define the Dream Outcome** — the single most desirable result, in the customer's words.
+1. **Identify your starving crowd** (§3) — score markets on pain, purchasing power, targetability, growth.
+2. **Define the Dream Outcome** (§1) — the single most desirable result, in the customer's words.
 3. **List every obstacle** — every problem, fear, objection, and friction point on the way.
 4. **Create solutions for each obstacle** — with a delivery vehicle (1-on-1, group, DIY, done-for-you, software, physical).
-5. **Apply Trim & Stack** — cut low-value/high-cost solutions; keep high-value/low-cost ones.
-6. **Set value-based pricing** — price at 10-20% of the Dream Outcome's value (10:1 to 5:1).
-7. **Design your bonuses** — one per remaining objection, each named with a defensible dollar value.
-8. **Choose your guarantee** — pick the type that fits your model and risk tolerance; name it; make it bold.
-9. **Add ethical scarcity and urgency** — real limits (seats, cohorts) and real deadlines.
-10. **Name the offer using MAGIC** — combine avatar, goal, timeframe, container; test 3-5 variations.
+5. **Apply Trim & Stack** (§2) — cut low-value/high-cost solutions; keep high-value/low-cost ones.
+6. **Set value-based pricing** (§4) — price at 10-20% of the Dream Outcome's value (10:1 to 5:1).
+7. **Design your bonuses** (§5) — one per remaining objection, each named with a defensible dollar value.
+8. **Choose your guarantee** (§6) — pick the type that fits your model and risk tolerance; name it; make it bold.
+9. **Add ethical scarcity and urgency** (§7) — real limits (seats, cohorts) and real deadlines.
+10. **Name the offer using MAGIC** (§8) — combine avatar, goal, timeframe, container; test 3-5 variations.
+
+See [references/offer-creation-checklist.md](references/offer-creation-checklist.md) to run this process as a fill-in worksheet (per-step prompts, scoring rubric, assembly template), and [references/case-studies.md](references/case-studies.md) for six full before/after offer redesigns (SaaS, coaching, e-commerce, agency, local, info product).
 
 ## Common Mistakes
 
@@ -298,19 +296,6 @@ Use this table to audit any existing offer:
 | Is there a real reason to act now? | "I'll think about it" | Add ethical scarcity/urgency with a real deadline |
 | Could a competitor offer the exact same thing? | Commodity; price war | Bundle elements that defy comparison |
 | Does the name say who it's for and what they get? | No self-selection | Rename using MAGIC |
-
-## Reference Files
-
-- [value-equation.md](references/value-equation.md): The four levers of the Value Equation, optimization tactics for each, and scoring rubric
-- [grand-slam-offers.md](references/grand-slam-offers.md): Full offer assembly process, problem-solution mapping, and the Trim & Stack method
-- [starving-crowd.md](references/starving-crowd.md): Market selection criteria, demand validation, and niche scorecard template
-- [pricing-strategy.md](references/pricing-strategy.md): Value-based pricing, anchoring techniques, payment plans, and the premium pricing cycle
-- [bonuses-stacking.md](references/bonuses-stacking.md): Bonus design framework, dollar value assignment, stacking order, and naming strategies
-- [guarantees.md](references/guarantees.md): Five guarantee types, naming guarantees, stacking guarantees, and legal considerations
-- [scarcity-urgency.md](references/scarcity-urgency.md): Ethical scarcity patterns, cohort models, evergreen urgency, and what not to do
-- [naming-offers.md](references/naming-offers.md): MAGIC formula breakdown, 20+ name examples, and A/B testing offer names
-- [case-studies.md](references/case-studies.md): Detailed offer breakdowns across SaaS, coaching, e-commerce, agency, local business, and info products
-- [offer-creation-checklist.md](references/offer-creation-checklist.md): Step-by-step worksheet, scoring rubric, and fill-in templates
 
 ## Further Reading
 

--- a/improve-retention/SKILL.md
+++ b/improve-retention/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: improve-retention
-description: 'Diagnose and fix retention problems using behavior design (B=MAP). Use when the user mentions "users drop off", "activation rate", "onboarding friction", "retention metrics", "why users dont complete", "churn analysis", "user activation", "aha moment", "people sign up but dont stick around", "boost retention", or "improve activation". Also trigger when analyzing cohort retention curves, designing activation milestones, reducing time-to-value for new users, or investigating why users quit after their first session. Covers the Ability Chain, prompt design, and tiny behaviors that compound. For habit loops and variable rewards, see hooked-ux. For intrinsic motivation, see drive-motivation.'
+description: 'Diagnose and fix retention problems using behavior design (B=MAP). Use when the user mentions "users sign up but dont stick around", "activation rate", "onboarding friction", "retention metrics", "why users dont complete", "churn analysis", or "aha moment". Also trigger when analyzing cohort retention curves, designing activation milestones, reducing time-to-value for new users, or investigating why users quit after their first session. Covers the Ability Chain, prompt design, and tiny behaviors that compound. For habit loops and variable rewards, see hooked-ux. For intrinsic motivation, see drive-motivation.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Behavior Design Framework
@@ -32,9 +32,11 @@ Framework for designing products that reliably change behavior. Behavior is not 
 
 **The Action Line:** When motivation and ability are sufficient, a prompt causes the behavior; below the line, no prompt works. High motivation compensates for low ability and vice versa. The reliable strategy is making behaviors easier (move right), not pumping up motivation (move up).
 
+See: [references/behavior-model.md](references/behavior-model.md) when you need the curve mechanics behind this model — the full Action Line math, behavior types (dot/span/path), and a step-by-step failure diagnostic for a behavior that isn't happening.
+
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating product behavior design, rate it 0-10 based on adherence to the principles below. A 10/10 means full alignment with all guidelines; lower scores indicate gaps to address. Always provide the current score and specific improvements needed to reach 10/10.
+**Goal: 10/10.** The six Quick Diagnostic rows are the single source of score-movers. Rate each pass/fail, then start at 10 and subtract per failing row: low motivation or below the Action Line (rows 1-2) cost **-2** each; prompts, celebration, bottleneck, and scaling (rows 3-6) cost **-1.5** each. A design that passes all six scores 10; one that fails every row scores 0. Map to bands: **9-10** = behavior reliably crosses the Action Line at low motivation, prompts are event/anchor-tied, key actions are celebrated; **5-6** = depends on a motivation spike or optimizes a non-bottleneck factor; **<=3** = core action below the Action Line, prompts are spam, no habit wiring. Always state the score and name the specific failing rows.
 
 ## The Three Elements
 
@@ -63,7 +65,7 @@ Framework for designing products that reliably change behavior. Behavior is not 
 - "Join 50,000 teams who..." (belonging motivator)
 - "Don't lose your 7-day streak" (anticipation/fear motivator)
 
-**Ethical boundary:** Never manufacture false hope or exploit fear — motivation tactics should connect users to genuine outcomes, not anxiety-driven compulsive usage.
+**Ethical boundary:** A fear motivator (the streak pattern above) is fair only when the loss is real and user-owned (their data, their progress); never invent a loss that exists solely to drive a session.
 
 See: [references/motivation-waves.md](references/motivation-waves.md) for the three motivators, motivation waves, and designing for troughs.
 
@@ -121,7 +123,7 @@ See: [references/ability-chain.md](references/ability-chain.md) for the six fact
 - "One thing left to complete your setup" (action prompt with progress)
 - Never: "We miss you!" (product need, not user need)
 
-**Ethical boundary:** Every prompt should pass the test "Would I appreciate receiving this right now?" — never manipulate through anxiety or manufactured urgency.
+**Ethical boundary:** Every prompt must pass the test "Would I appreciate receiving this right now?" — if it serves a product metric (DAU, re-engagement) but not the user's current goal, cut it.
 
 See: [references/prompt-design.md](references/prompt-design.md) for prompt types, timing strategies, notification design, and anchor moments.
 
@@ -174,6 +176,8 @@ Shrink the best-matched behavior to its Starter Step; design the prompt; add cel
 ### Step 5: Optimize
 Expand once wired. Fix bottlenecks with the Ability Chain; refine prompt timing from data.
 
+See: [references/product-applications.md](references/product-applications.md) when applying this process to a specific category — B=MAP mapped to SaaS onboarding, mobile, e-commerce, health, and education with per-category motivation timelines and bottlenecks.
+
 ## The Action Line
 
 ### Moving Behaviors Above the Action Line
@@ -194,6 +198,8 @@ Map B=MAP to product metrics:
 | **Day-30 drop-off** | Habit didn't form, no internal prompt | Create tiny habit recipe; add celebration loops |
 | **Low feature adoption** | Feature below the Action Line for most users | Friction-audit it; prompt only when motivation is present |
 | **Notification fatigue** | Prompts sent below the Action Line | Cut volume; send only with motivation + ability |
+
+See: [references/case-studies.md](references/case-studies.md) for a worked diagnosis of Instagram, Duolingo, Slack, Calm, and Peloton — read it to see how M, A, and P are scored independently on a real product before diagnosing your own.
 
 ## Common Mistakes
 
@@ -216,16 +222,6 @@ Map B=MAP to product metrics:
 | Is there immediate feedback after key actions? | No celebration = no habit wiring | Add success states, progress, social feedback |
 | Have you found the weakest Ability Chain link? | Optimizing the wrong thing | Rate each of the six factors 1-5 for the core behavior |
 | Do users scale naturally from tiny behaviors? | Forcing complexity too early | Starter Steps; let behaviors grow organically |
-
-## Reference Files
-
-- [behavior-model.md](references/behavior-model.md): B=MAP deep dive, the Action Line, behavior types, failure diagnostics
-- [ability-chain.md](references/ability-chain.md): Six simplicity factors, friction audit templates, simplification strategies
-- [prompt-design.md](references/prompt-design.md): Three prompt types, timing strategies, notification design, anchor moments
-- [tiny-habits.md](references/tiny-habits.md): Tiny Habits recipe, Starter Steps, celebration, scaling patterns
-- [motivation-waves.md](references/motivation-waves.md): Three motivators, motivation waves, designing for troughs
-- [product-applications.md](references/product-applications.md): B=MAP applied to SaaS, mobile, e-commerce, health, education
-- [case-studies.md](references/case-studies.md): Instagram, Duolingo, Slack, Calm, Peloton through Fogg's lens
 
 ## Further Reading
 

--- a/influence-psychology/SKILL.md
+++ b/influence-psychology/SKILL.md
@@ -4,7 +4,7 @@ description: 'Apply the seven principles of ethical persuasion (reciprocity, com
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # Influence Psychology Framework
@@ -17,11 +17,12 @@ Apply six decades of persuasion science — Cialdini's research into why people 
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating persuasive elements (features, copy, flows, campaigns), score by counting satisfied rows in the Quick Diagnostic (one point each), then apply the ethics gate. Always report the current score and the specific change needed to reach 10/10.
+**Goal: 10/10.** When reviewing or creating persuasive elements (features, copy, flows, campaigns), run the Quick Diagnostic, then score against the bands below and apply the ethics gate. Always report the current score and the specific change needed to reach 10/10.
 
-- **9-10** — At least two principles deliberately layered, every claim truthful, users can reverse, and the tactic passes the transparency test (still works if the user knows the strategy).
-- **5-6** — One principle present but generic, or leverage left on the table (single principle where layering is possible).
-- **<=3** — No principle is deliberately designed (relying on luck), OR any tactic is deceptive/coercive. Any fabricated proof, fake scarcity, or hidden-cost dark pattern caps the score at 3 regardless of other strengths.
+- **9-10** — Multiple principles deliberately layered; every claim truthful; users can reverse the decision; passes the transparency test (still works if the user knows the strategy); safe for vulnerable users.
+- **7-8** — Principles deliberately layered and honest, but one gap (e.g. weak reversibility, or a single principle where layering was possible).
+- **5-6** — One principle present but generic, or leverage left on the table.
+- **<=3** — No principle deliberately designed (relying on luck), OR any tactic is deceptive/coercive. Any fabricated proof, fake scarcity, or hidden-cost dark pattern caps the score at 3 regardless of other strengths.
 
 ## The Seven Principles of Influence
 

--- a/influence-psychology/SKILL.md
+++ b/influence-psychology/SKILL.md
@@ -1,15 +1,15 @@
 ---
 name: influence-psychology
-description: 'Apply the six principles of ethical persuasion (reciprocity, commitment, social proof, authority, liking, scarcity) to product design, copy, and sales. Use when the user mentions "social proof", "persuasive copy", "why users dont convert", "ethical persuasion", "reciprocity", "scarcity tactics", "commitment and consistency", "make my copy more persuasive", "increase trust", or "get more people to say yes". Also trigger when designing testimonial sections, crafting urgency messaging, or improving trust signals on landing pages. Covers the principles, when each applies, and ethical limits. For deal negotiation tactics, see negotiation. For viral word-of-mouth, see contagious.'
+description: 'Apply the seven principles of ethical persuasion (reciprocity, commitment, social proof, authority, liking, scarcity, unity) to product design, copy, and sales. Use when the user mentions "social proof", "persuasive copy", "why users dont convert", "ethical persuasion", "reciprocity", "scarcity tactics", "commitment and consistency", "shared identity", "in-group", "make my copy more persuasive", "increase trust", or "get more people to say yes". Also trigger when designing testimonial sections, crafting urgency messaging, or improving trust signals on landing pages. Covers the principles, when each applies, and ethical limits. For deal negotiation tactics, see negotiation. For viral word-of-mouth, see contagious.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Influence Psychology Framework
 
-Framework for applying the science of persuasion ethically and effectively — six decades of research into why people say "yes."
+Apply six decades of persuasion science — Cialdini's research into why people say "yes" — to product, copy, and sales, ethically.
 
 ## Core Principle
 
@@ -17,7 +17,11 @@ Framework for applying the science of persuasion ethically and effectively — s
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating persuasive elements (features, copy, flows, campaigns), rate them 0-10 based on adherence to the principles below. A 10/10 means ethical, effective application of influence psychology; lower scores indicate missed opportunities or ethical concerns. Always provide the current score and specific improvements needed to reach 10/10.
+**Goal: 10/10.** When reviewing or creating persuasive elements (features, copy, flows, campaigns), score by counting satisfied rows in the Quick Diagnostic (one point each), then apply the ethics gate. Always report the current score and the specific change needed to reach 10/10.
+
+- **9-10** — At least two principles deliberately layered, every claim truthful, users can reverse, and the tactic passes the transparency test (still works if the user knows the strategy).
+- **5-6** — One principle present but generic, or leverage left on the table (single principle where layering is possible).
+- **<=3** — No principle is deliberately designed (relying on luck), OR any tactic is deceptive/coercive. Any fabricated proof, fake scarcity, or hidden-cost dark pattern caps the score at 3 regardless of other strengths.
 
 ## The Seven Principles of Influence
 
@@ -45,9 +49,7 @@ Framework for applying the science of persuasion ethically and effectively — s
 - "As a thank you for signing up..."
 - "We noticed you needed help with X, so we..."
 
-**Ethical boundary:** Give genuine value — don't create artificial debts or exploit obligation.
-
-See: [references/reciprocity.md](references/reciprocity.md) for reciprocity techniques and case studies.
+See [references/reciprocity.md](references/reciprocity.md) when building free trials, lead magnets, or referral rewards — gift tiers, email templates, day-by-day reciprocity-stacking, and A/B variables.
 
 ### 2. Commitment & Consistency
 
@@ -75,9 +77,9 @@ See: [references/reciprocity.md](references/reciprocity.md) for reciprocity tech
 
 **Onboarding sequence:** micro-commitment ("What brings you here?") → small action (click, choice) → public/written commitment (goal) → reinforce ("Based on what you told us...").
 
-**Ethical boundary:** Don't lock users into commitments they didn't freely make — allow easy reversibility.
+**Ethical boundary:** Make every commitment freely chosen and easily reversible — no trick opt-ins or locked-in defaults the user can't undo.
 
-See: [references/commitment-consistency.md](references/commitment-consistency.md) for commitment tactics and flows.
+See [references/commitment-consistency.md](references/commitment-consistency.md) when designing onboarding or goal-setting flows — foot-in-the-door sequences and public-commitment tactics.
 
 ### 3. Social Proof
 
@@ -114,9 +116,9 @@ See: [references/commitment-consistency.md](references/commitment-consistency.md
 - "[Name/Company] increased [metric] by [%]"
 - "Don't take our word for it. Here's what [users] say..."
 
-**Ethical boundary:** Never fabricate social proof — real numbers, real testimonials, and disclose when proof is curated.
+**Ethical boundary:** Disclose when proof is curated or cherry-picked (e.g. "selected reviews") rather than presenting it as representative.
 
-See: [references/social-proof.md](references/social-proof.md) for social proof types and implementation patterns.
+See [references/social-proof.md](references/social-proof.md) when building testimonial sections or trust bars — proof types and implementation patterns.
 
 ### 4. Authority
 
@@ -152,15 +154,13 @@ See: [references/social-proof.md](references/social-proof.md) for social proof t
 - "Research shows that [cite source]..."
 - "Our team includes [credentials]"
 
-**Ethical boundary:** Never fake credentials or fabricate expertise — cite real sources, and be transparent about what you're not good at.
-
-See: [references/authority.md](references/authority.md) for authority-building strategies.
+See [references/authority.md](references/authority.md) when writing About pages, bylines, or trust badges — credential framing and thought-leadership strategies.
 
 ### 5. Liking
 
 **Core concept:** People prefer to say yes to those they like.
 
-**Why it works:** Liking creates psychological safety and reduces resistance — we're more persuaded by people we trust and feel connected to.
+**Why it works:** Each liking factor (similarity, compliments, cooperation) is a separate lever that independently lowers a person's resistance to a request — they stack.
 
 **Factors that increase liking:**
 
@@ -186,9 +186,7 @@ See: [references/authority.md](references/authority.md) for authority-building s
 - "We built this because we were frustrated with..."
 - Casual, warm language ("Hey", "Awesome!", "We got you")
 
-**Ethical boundary:** Be genuinely helpful and authentic — don't manufacture false rapport or manipulate emotions.
-
-See: [references/liking.md](references/liking.md) for liking techniques and tone guidelines.
+See [references/liking.md](references/liking.md) when setting brand voice or writing support replies — liking factors and tone guidelines. For ready-to-adapt persuasive copy across all seven principles, see [references/copywriting.md](references/copywriting.md).
 
 ### 6. Scarcity
 
@@ -223,9 +221,9 @@ See: [references/liking.md](references/liking.md) for liking techniques and tone
 - "Offer expires [specific date]"
 - "[X] people are viewing this right now"
 
-**Ethical boundaries:** Never fake scarcity, and let users decide rationally. Ethical: real inventory counts, genuine deadlines, legitimate capacity limits. Unethical: artificial limits, resetting countdown timers, "Only 2 left!" repeated daily, pressuring vulnerable users.
+**Ethical boundary:** Ethical scarcity reflects real constraints (true inventory counts, genuine deadlines, legitimate capacity limits). Unethical: invented limits, countdown timers that reset, "Only 2 left!" shown daily, pressuring vulnerable users.
 
-See: [references/scarcity.md](references/scarcity.md) for scarcity tactics and ethical implementation.
+See [references/scarcity.md](references/scarcity.md) when adding urgency or waitlists — five scarcity types, each with an "ethical when" line and the dark patterns to avoid.
 
 ### 7. Unity
 
@@ -257,9 +255,9 @@ See: [references/scarcity.md](references/scarcity.md) for scarcity tactics and e
 - "Join [X] others who believe..."
 - "We're building this together"
 
-**Ethical boundary:** Don't create toxic in-groups or vilify out-groups — unity should unite, not divide maliciously.
+**Ethical boundary:** Build the in-group by what it stands for, not by vilifying an out-group — define "us" without manufacturing a "them" to resent.
 
-See: [references/unity.md](references/unity.md) for unity-building strategies.
+See [references/unity.md](references/unity.md) when defining a brand tribe or community — identity-marketing and co-creation strategies.
 
 ## Combining Principles
 
@@ -269,21 +267,13 @@ The most powerful persuasion layers multiple principles:
 
 **Referral program:** reciprocity (reward both parties) + social proof ("X friends already joined") + unity ("Invite your team") + commitment (ask after a good experience).
 
-## Ethical Application Checklist
+See [references/case-studies.md](references/case-studies.md) for full worked teardowns of multi-principle stacks across industries.
 
-Before deploying influence tactics:
+## The Ethical Line
 
-- [ ] **Is it truthful?** No fake scarcity, fabricated proof, or false credentials
-- [ ] **Does it help the user?** Persuasion should align with user goals, not exploit them
-- [ ] **Is it transparent?** You're not hiding how you're influencing
-- [ ] **Is it reversible?** Users can easily undo commitments
-- [ ] **Would you use it on yourself/family?** The golden rule of persuasion
-- [ ] **Does it respect autonomy?** Users feel in control, not manipulated
-- [ ] **Are you targeting vulnerable groups?** Extra caution with children, elderly, desperate
+**Persuasion helps people see value they'd appreciate anyway; manipulation tricks people into choices against their interests.** The deciding tests are in the Quick Diagnostic below — run every persuasive element through them before shipping.
 
-**The line:** persuasion helps people see value they'd appreciate anyway; manipulation tricks people into choices against their interests.
-
-See: [references/ethics.md](references/ethics.md) for comprehensive ethical boundaries.
+See [references/ethics.md](references/ethics.md) when a tactic feels borderline or you ship to vulnerable users — the persuasion-vs-manipulation decision tree, the regulatory landscape (FTC, GDPR, DSA, dark-patterns law), vulnerable-population safeguards, and audit templates.
 
 ## Common Mistakes
 
@@ -302,23 +292,12 @@ Audit any persuasive element:
 | Question | If No | Action |
 |----------|-------|--------|
 | Which principle(s) am I using? | You're relying on luck | Explicitly design for influence |
-| Is this claim/tactic truthful? | You're manipulating | Remove or replace with truth |
-| Would this work on me? | It probably won't work on others | Redesign with genuine value |
 | Am I combining principles? | Missing leverage | Layer multiple principles |
-| Can users easily reverse? | Ethical concern | Add clear opt-outs |
-
-## Reference Files
-
-- [reciprocity.md](references/reciprocity.md): Reciprocity techniques, gift strategies, examples
-- [commitment-consistency.md](references/commitment-consistency.md): Commitment flows, foot-in-the-door, public commitment tactics
-- [social-proof.md](references/social-proof.md): Social proof types, implementation patterns, case studies
-- [authority.md](references/authority.md): Building authority, credentials, thought leadership
-- [liking.md](references/liking.md): Liking factors, brand voice, rapport-building
-- [scarcity.md](references/scarcity.md): Scarcity tactics, ethical vs. manipulative scarcity
-- [unity.md](references/unity.md): Tribe-building, identity marketing, community
-- [ethics.md](references/ethics.md): Ethical boundaries, manipulation vs. persuasion
-- [case-studies.md](references/case-studies.md): Real-world applications across industries
-- [copywriting.md](references/copywriting.md): Influence-based copy frameworks
+| Is this claim/tactic truthful? | You're manipulating | Remove or replace with truth |
+| Does it help the user (not just convert)? | You're exploiting, not persuading | Realign the tactic with the user's goal |
+| Would it still work if the user knew the strategy? | The tactic relies on deception | Replace with a transparent version |
+| Can users easily reverse the decision? | Ethical concern | Add clear opt-outs |
+| Safe for vulnerable users (children, elderly, distressed)? | Heightened-harm risk | Apply ethics.md safeguards or exclude them |
 
 ## Further Reading
 

--- a/inspired-product/SKILL.md
+++ b/inspired-product/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: inspired-product
-description: 'Build empowered product teams using discovery and delivery dual-track. Use when the user mentions "product discovery", "empowered teams", "feature factory", "product roadmap", "opportunity assessment", "product vision", "product-led growth", "discovery vs delivery", "what should we build", "our roadmap is just a feature list", or "set our product strategy". Also trigger when restructuring product teams away from output-driven models, setting product strategy, or deciding what to build next based on outcomes. Covers product discovery techniques, team structure, and continuous value delivery. For customer interviews, see mom-test. For ongoing discovery systems, see continuous-discovery.'
+description: 'Build empowered product teams using discovery and delivery dual-track. Use when the user mentions "product discovery", "empowered teams", "feature factory", "opportunity assessment", "product vision", "product strategy", "what should we build", or "our roadmap is just a feature list". Also trigger when restructuring teams away from output-driven models, or deciding what to build next based on outcomes. Covers discovery techniques, team structure, opportunity assessment, vision/strategy, and continuous delivery. For customer interviews, see mom-test. For ongoing discovery systems, see continuous-discovery.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Empowered Product Teams Framework
@@ -19,7 +19,7 @@ Most product failures come not from bad engineering or design but from building 
 
 ## Scoring
 
-**Goal: 10/10.** Rate product team structures, discovery practices, or delivery processes 0-10 against the principles below. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 7/7.** Score product team structures, discovery practices, or delivery processes by the Quick Diagnostic below -- **1 point per satisfied row**, scored 0-7. Bands: **6-7** = empowered teams own outcomes and discovery runs continuously with engineers; **4-5** = discovery happens but inconsistently, or teams own output with partial outcome accountability; **<=3** = a feature factory: teams receive a roadmap of dated features and skip discovery. Always state the current score and the specific failed diagnostic rows to fix to reach 7/7.
 
 ## Framework
 
@@ -43,15 +43,15 @@ Most product failures come not from bad engineering or design but from building 
 | Roadmap prioritization | Prioritize strongest discovery evidence | Ship the feature with 4/5 successful user tests, not the CEO's request |
 | Sprint planning | Feed backlog from validated discovery output | Only discovery-tested items enter the sprint |
 
-**Ethical boundary:** Never cherry-pick discovery evidence to justify a predetermined conclusion -- discovery is honest inquiry, not confirmation theater.
+**Ethical boundary:** Never cherry-pick discovery evidence to justify a conclusion you already chose; report the tests that failed alongside the ones that passed.
 
-See: [references/discovery-techniques.md](references/discovery-techniques.md) for the four risks framework, prototyping techniques, and user testing.
+See [references/discovery-techniques.md](references/discovery-techniques.md) when planning a discovery cycle -- the four-risks framework, a 5-stage interview script, prototyping techniques, and concrete evidence thresholds for "validated".
 
 ### 2. Empowered Product Teams
 
 **Core concept:** A small, durable, cross-functional group (product manager, product designer, engineers) given a problem to solve, owning discovery and delivery, accountable for outcomes rather than output.
 
-**Why it works:** Teams that own problems end-to-end develop the domain expertise, customer empathy, and creative solutions no top-down roadmap can match -- missionaries who believe in what they build because they discovered it.
+**Why it works:** The people closest to the customer and the technology find better solutions than a remote roadmap author -- and a team that discovered the solution itself defends and refines it under pressure, where a team handed a spec ships it and moves on.
 
 **Key insights:**
 - The PM is not a project manager or backlog administrator -- they own value and viability and need deep knowledge of customers, data, business, and industry
@@ -70,7 +70,7 @@ See: [references/discovery-techniques.md](references/discovery-techniques.md) fo
 
 **Ethical boundary:** Never claim to empower teams while overriding their discovery findings with executive mandates -- if leadership dictates the solution, the team is not empowered.
 
-See: [references/empowered-teams.md](references/empowered-teams.md) for roles, missionary vs mercenary dynamics, coaching, and accountability.
+See [references/empowered-teams.md](references/empowered-teams.md) when staffing or diagnosing a team -- role-by-role competence breakdowns with red flags, missionary vs mercenary dynamics, coaching, and a feature-factory-to-empowered transformation table.
 
 ### 3. Product Discovery Techniques
 
@@ -117,7 +117,9 @@ See: [references/empowered-teams.md](references/empowered-teams.md) for roles, m
 | Stakeholder requests | Respond with assessment, not commitment | "Let me assess this and share findings before we commit engineering" |
 | Resource allocation | Fund highest-assessed opportunities | Severe pain + clear business alignment beats the nice-to-have |
 
-See: [references/opportunity-assessment.md](references/opportunity-assessment.md) for evaluation questions, market assessment, and prioritization.
+See [references/opportunity-assessment.md](references/opportunity-assessment.md) when sizing a new opportunity before design work -- the full evaluation-question set, market-timing assessment, and prioritization scoring.
+
+See [references/stakeholder-management.md](references/stakeholder-management.md) when an executive or sales stakeholder hands you a solution or a HiPPO is steering the roadmap -- stakeholder mapping, turning a mandate into a problem to assess, evangelism, and building executive trust.
 
 ### 5. Product Vision and Strategy
 
@@ -140,9 +142,9 @@ See: [references/opportunity-assessment.md](references/opportunity-assessment.md
 | Team autonomy | Strategy scopes each team's focus | "This quarter: cut mid-market churn via top 3 pain points" |
 | Decision-making | Principles resolve tradeoffs | "When in doubt, choose simplicity over power" |
 
-**Ethical boundary:** Never present a vision you know is unachievable to motivate teams or attract investment -- ambitious but honest.
+**Ethical boundary:** Never present a vision you know is unachievable to motivate teams or attract investment.
 
-See: [references/product-vision.md](references/product-vision.md) for vision, strategy, principles, OKRs, and outcome-based roadmaps.
+See [references/product-vision.md](references/product-vision.md) when drafting or revisiting vision and strategy -- how to write each, product principles, translating strategy into OKRs, and building outcome-based roadmaps.
 
 ### 6. Continuous Value Delivery
 
@@ -165,9 +167,9 @@ See: [references/product-vision.md](references/product-vision.md) for vision, st
 | Risk management | Feature flags for controlled rollout | Ship to 5%, measure, expand or roll back |
 | Learning loops | Instrument every release to feed discovery | Low search usage triggers a discovery investigation |
 
-**Ethical boundary:** Never ship changes you cannot roll back -- continuous delivery requires continuous responsibility for the user experience.
+**Ethical boundary:** Never ship a change you cannot roll back; gate anything risky behind a flag you can flip off.
 
-See: [references/case-studies.md](references/case-studies.md) for these principles applied at different company stages.
+See [references/case-studies.md](references/case-studies.md) when you want a worked example before applying the framework -- these principles played out at startup, growth, and enterprise stages.
 
 ## Common Mistakes
 
@@ -179,7 +181,6 @@ See: [references/case-studies.md](references/case-studies.md) for these principl
 | Handing teams solutions, not problems | Feature factories with no motivation or creativity | Assign objectives and key results; let teams discover solutions |
 | Isolating engineers from customers | Best source of innovation never sees the problem | Include engineers in interviews, discovery, prototype testing |
 | Roadmaps of promised features with dates | Commitments calcify before discovery can validate | Use outcome-based roadmaps: problems to solve, not features |
-| Discovery as a one-time phase | Learning stops once building starts | Run discovery continuously in parallel with delivery |
 
 ## Quick Diagnostic
 
@@ -192,15 +193,6 @@ See: [references/case-studies.md](references/case-studies.md) for these principl
 | Can team members explain the vision and strategy? | No context for autonomous decisions | Create and evangelize a vision doc and quarterly strategy |
 | Do stakeholders bring problems, not solutions? | Leadership dictating features | Coach stakeholders on discovery; pre-sell with opportunity assessments |
 | Do you ship validated increments at least every two weeks? | Too slow to learn | Smaller increments; invest in CI/CD and feature flags |
-
-## Reference Files
-
-- [discovery-techniques.md](references/discovery-techniques.md): Opportunity discovery, solution discovery, prototyping techniques, user testing, and the four risks framework
-- [empowered-teams.md](references/empowered-teams.md): Product team structure, roles, missionary vs mercenary teams, coaching, and accountability
-- [opportunity-assessment.md](references/opportunity-assessment.md): Evaluating product opportunities, business alignment, market assessment, and prioritization
-- [product-vision.md](references/product-vision.md): Creating product vision, strategy, principles, OKRs, and outcome-based roadmaps
-- [stakeholder-management.md](references/stakeholder-management.md): Managing stakeholders, evangelism, getting buy-in, dealing with HiPPOs, and building executive trust
-- [case-studies.md](references/case-studies.md): Scenarios showing empowered product team principles applied to different company stages
 
 ## Further Reading
 

--- a/ios-hig-design/SKILL.md
+++ b/ios-hig-design/SKILL.md
@@ -4,7 +4,7 @@ description: 'Design native iOS interfaces following Apple Human Interface Guide
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # iOS Human Interface Guidelines Design Skill
@@ -19,15 +19,13 @@ Apple's iOS design philosophy rests on three pillars: **clarity** (every element
 
 ## Scoring
 
-**Goal: 10/10.** Rate iOS interfaces or SwiftUI/UIKit code 0-10 against the principles below. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score 1 point per satisfied row of the Quick Diagnostic (6 rows), plus up to 4 points for native idiom: +1 semantic colors/text styles throughout (no hardcoded values), +1 system controls over custom reimplementations, +1 standard gestures and meaningful haptics, +1 SF Symbols and correct app-icon shape. Bands: **9-10** = native, accessible, adapts to Dark Mode and Dynamic Type, zero foreign patterns; **5-6** = works but leaks Android idioms or hardcodes color/size; **<=3** = fails safe areas, touch targets, or VoiceOver. Always state the score and the specific improvements needed to reach 10/10.
 
 ## iOS Design Framework
 
 ### 1. Layout & Safe Areas
 
 **Core concept:** iOS devices have specific screen dimensions, safe area insets, and hardware intrusions (notch, Dynamic Island, home indicator) that every layout must respect.
-
-**Why it works:** When layouts respect safe areas and standard spacing, the app feels native and trustworthy---no content hides behind hardware features, and the visual rhythm matches the platform.
 
 **Key insights:**
 - Design for the smallest screen first (375pt width, iPhone SE)
@@ -39,8 +37,8 @@ Apple's iOS design philosophy rests on three pillars: **clarity** (every element
 
 | Context | Layout Pattern | Example |
 |---------|---------------|---------|
-| **Status bar** | 59pt height, always respected | Time, signal, battery area |
-| **Navigation bar** | 44pt standard row + 58pt large title | Back button, title, actions |
+| **Status bar** | 20pt classic, 44-54pt on Dynamic Island devices | Time, signal, battery area |
+| **Navigation bar** | 44pt standard row + ~52pt large title (~96pt total) | Back button, title, actions |
 | **Content area** | Flexible, scrollable, respects safe area | Main app content |
 | **Tab bar** | 49pt height, translucent with blur | 2-5 primary destinations |
 | **Home indicator** | 34pt inset at bottom | System gesture area |
@@ -50,19 +48,15 @@ Apple's iOS design philosophy rests on three pillars: **clarity** (every element
 - Use `.ignoresSafeArea()` only for backgrounds and decoration, never interactive content
 - Test on multiple sizes, including iPhone SE and Pro Max
 
-**Ethical boundary:** Never hide critical content or controls behind hardware intrusions---every device deserves equal access to all functionality.
-
-See: [references/navigation.md](references/navigation.md) for detailed navigation bar and tab bar specifications.
+See [references/navigation.md](references/navigation.md) when laying out chrome---exact nav bar and tab bar dimensions, large-title behavior, and split-view rules.
 
 ### 2. Typography & Dynamic Type
 
-**Core concept:** iOS uses the San Francisco (SF Pro) typeface with semantic text styles that automatically scale for accessibility via Dynamic Type.
-
-**Why it works:** Semantic styles create consistent hierarchy across the platform, and Dynamic Type lets every user---including those with visual impairments---read at their preferred size without breaking layouts.
+**Core concept:** iOS uses the San Francisco (SF Pro) typeface with semantic text styles that automatically scale for accessibility via Dynamic Type. Semantic styles give consistent platform hierarchy; Dynamic Type lets users read at their preferred size without breaking layouts.
 
 **Key insights:**
 - Large Title: 34pt Bold; Title: 17pt Medium; Body: 17pt Regular; Caption: 12-13pt; secondary text: 15pt at 60% opacity
-- Minimum text size 11pt (captions/secondary only); minimum contrast 4.5:1 (WCAG AA)
+- Minimum text size 11pt (captions/secondary only)
 - Line height at least 1.3x font size; optimal line length 35-50 characters on mobile
 - Always left-aligned, non-justified text
 
@@ -81,15 +75,11 @@ See: [references/navigation.md](references/navigation.md) for detailed navigatio
 - Prefer weight and color variation over extreme size differences for hierarchy
 - Test all layouts at the largest Dynamic Type size
 
-**Ethical boundary:** Never disable Dynamic Type or fix font sizes that block accessibility scaling---every user deserves readable text.
-
-See: [references/typography.md](references/typography.md) for complete text styles, font sizes, and Dark Mode typography rules.
+See [references/typography.md](references/typography.md) when matching a design to exact specs---per-style hex values and the Dark Mode text-color mapping.
 
 ### 3. Color & Dark Mode
 
 **Core concept:** iOS provides semantic system colors that automatically adapt between light and dark appearances while preserving contrast and hierarchy.
-
-**Why it works:** Semantic colors maintain readability across appearances without manual intervention, so Dark Mode users get a first-class experience and the app feels polished and native.
 
 **Key insights:**
 - Use `Color(.label)`, `Color(.secondaryLabel)`, `Color(.systemBackground)` instead of hardcoded colors
@@ -112,15 +102,11 @@ See: [references/typography.md](references/typography.md) for complete text styl
 - Define custom colors in the Asset Catalog with light/dark variants, not in code
 - Never assume a background is white or black; test with Increase Contrast enabled
 
-**Ethical boundary:** Dark Mode is not optional polish---never ship an app that is unreadable or broken in it.
-
-See: [references/colors-depth.md](references/colors-depth.md) for semantic colors, Dark Mode palette, and contrast ratio guidelines.
+See [references/colors-depth.md](references/colors-depth.md) when checking contrast---the full WCAG ratio table (normal text, large text, UI components) and the tertiary/grouped-background tokens.
 
 ### 4. Navigation Patterns
 
-**Core concept:** iOS uses a layered navigation model: tab bars for primary destinations, navigation stacks for hierarchical drilling, and modals for focused tasks.
-
-**Why it works:** Consistent navigation means users always know where they are, how they got there, and how to go back; violating these patterns makes the app feel foreign on iOS.
+**Core concept:** iOS uses a layered navigation model: tab bars for primary destinations, navigation stacks for hierarchical drilling, and modals for focused tasks. Users rely on these patterns to know where they are and how to get back; reinventing them makes the app feel foreign.
 
 **Key insights:**
 - Tab bar: 2-5 primary destinations, always visible, remembers state per tab
@@ -143,8 +129,6 @@ See: [references/colors-depth.md](references/colors-depth.md) for semantic color
 - Back button text should be the previous screen's title, not "Back"
 - Tab labels are single words ("Home", "Search"); modal titles describe the task ("New Message", "Edit Profile")
 - Use `NavigationStack` (not deprecated `NavigationView`) in SwiftUI
-
-**Ethical boundary:** Never trap users in flows without a clear exit---every screen needs an obvious way back or out.
 
 ### 5. Controls & Inputs
 
@@ -176,19 +160,17 @@ See: [references/colors-depth.md](references/colors-depth.md) for semantic color
 
 **Ethical boundary:** Never disguise ads as native controls or make destructive actions easy to trigger accidentally.
 
-See: [references/components.md](references/components.md) for buttons, lists, input controls, menus, and confirmation dialogs. See also: [references/keyboard-input.md](references/keyboard-input.md) for keyboard types and input patterns.
+See [references/components.md](references/components.md) when building a specific control---button styles, list/section variants, picker vs segmented-control choice, and confirmation-dialog wiring. See [references/keyboard-input.md](references/keyboard-input.md) when building forms---keyboard-type table, input accessory views, and hardware-keyboard shortcuts.
 
 ### 6. Accessibility
 
-**Core concept:** iOS has world-class accessibility features (VoiceOver, Dynamic Type, Switch Control, Voice Control), and every app must support them as a first-class concern.
-
-**Why it works:** Over 1 billion people live with some form of disability, and accessible apps benefit everyone (larger text in sunlight, VoiceOver while driving). App Store guidelines require it.
+**Core concept:** iOS has world-class accessibility features (VoiceOver, Dynamic Type, Switch Control, Voice Control), and every app must support them as a first-class concern. App Store review can reject apps that are unusable with assistive technologies.
 
 **Key insights:**
 - Every interactive element needs an `.accessibilityLabel`; use `.accessibilityValue` for state and `.accessibilityHint` for effect
 - Group related elements with `.accessibilityElement(children: .combine)`
 - Support Dynamic Type at all sizes; test at the largest setting
-- Minimum touch target 44 x 44pt; minimum text contrast 4.5:1 (WCAG AA)
+- Honor the 44 x 44pt touch target (section 1) and 4.5:1 contrast minimum (section 3) as accessibility requirements, not just visual defaults
 - Never convey meaning through color alone
 
 **Product applications:**
@@ -206,15 +188,11 @@ See: [references/components.md](references/components.md) for buttons, lists, in
 - Test the complete app flow using only VoiceOver
 - Use Xcode's Accessibility Inspector to audit contrast and labels
 
-**Ethical boundary:** Shipping an inaccessible app excludes real people---treat VoiceOver testing as seriously as visual testing.
-
-See: [references/accessibility.md](references/accessibility.md) for VoiceOver implementation, Dynamic Type support, and the accessibility checklist.
+See [references/accessibility.md](references/accessibility.md) before sign-off---the full VoiceOver-implementation patterns and a pre-ship accessibility checklist to run the app against.
 
 ### 7. Icons & Images
 
-**Core concept:** iOS uses SF Symbols as the standard icon system and requires app icons in specific sizes with the signature superellipse ("squircle") mask applied automatically.
-
-**Why it works:** SF Symbols align perfectly with San Francisco text, scale with Dynamic Type, and adapt to weights and sizes; consistent iconography makes the interface feel cohesive and native.
+**Core concept:** iOS uses SF Symbols as the standard icon system and requires app icons in specific sizes with the signature superellipse ("squircle") mask applied automatically. SF Symbols align optically with San Francisco text and scale with Dynamic Type, so they stay aligned and crisp at every weight and size.
 
 **Key insights:**
 - Use SF Symbols (`Image(systemName:)`) for all standard icons---they scale with text
@@ -238,13 +216,11 @@ See: [references/accessibility.md](references/accessibility.md) for VoiceOver im
 
 **Ethical boundary:** Never use icons that suggest functionality that doesn't exist or contradict iOS conventions (trash = delete, not archive).
 
-See: [references/app-icons.md](references/app-icons.md) for icon size tables, shape specifications, and design guidelines.
+See [references/app-icons.md](references/app-icons.md) when exporting the app icon---per-context size table, exact squircle math, and the iOS 18 light/dark/tinted variant requirements.
 
 ### 8. Gestures & Haptics
 
-**Core concept:** iOS defines standard gestures (swipe back, pull to refresh, long press for context menu) and haptic feedback patterns that must be respected and never overridden.
-
-**Why it works:** Gestures are muscle memory---overriding swipe-back or repurposing pull-to-refresh disorients users. Haptics provide invisible confirmation that an action registered.
+**Core concept:** iOS defines standard gestures (swipe back, pull to refresh, long press for context menu) and haptic feedback patterns that must be respected and never overridden. Gestures are muscle memory---repurposing swipe-back or pull-to-refresh disorients users; haptics give invisible confirmation that an action registered.
 
 **Key insights:**
 - Never override: swipe-right-from-edge (back), swipe-down on modal (dismiss), pull-down on list (refresh)
@@ -267,9 +243,7 @@ See: [references/app-icons.md](references/app-icons.md) for icon size tables, sh
 - `UINotificationFeedbackGenerator()` with `.success`, `.warning`, `.error` for outcomes
 - Call `.prepare()` before triggering haptics to minimize latency
 
-**Ethical boundary:** Haptic feedback should confirm, never coerce.
-
-See: [references/gestures.md](references/gestures.md) for the standard gesture table, haptic patterns, and animation guidelines.
+See [references/gestures.md](references/gestures.md) when wiring gestures or animation---the full reserved-gesture table, haptic-generator recipes, and standard animation timing/curves.
 
 ## Common Mistakes
 
@@ -297,19 +271,13 @@ Audit any iOS interface design:
 | Can a VoiceOver user complete every task? | App inaccessible to blind users | Add labels, values, hints to all interactive elements |
 | Are navigation patterns native iOS? | App feels foreign | Replace hamburger menus with tab bars; standard push/modal navigation |
 
-## Reference Files
+## Beyond Core UI
 
-- [typography.md](references/typography.md): Text styles, font sizes, Dynamic Type, Dark Mode typography
-- [navigation.md](references/navigation.md): Tab bar, navigation bar, modals, search patterns, split views
-- [components.md](references/components.md): Buttons, lists, input controls, menus, confirmation dialogs
-- [colors-depth.md](references/colors-depth.md): Semantic colors, Dark Mode, contrast ratios
-- [gestures.md](references/gestures.md): Standard gestures, haptics, animations
-- [accessibility.md](references/accessibility.md): VoiceOver, Dynamic Type, accessibility checklist
-- [app-icons.md](references/app-icons.md): Icon sizes, shape, SF Symbols guidelines
-- [keyboard-input.md](references/keyboard-input.md): Keyboard types, input accessory views, hardware keyboard support
-- [privacy-permissions.md](references/privacy-permissions.md): Permission request timing, pre-permission screens, handling denial
-- [widgets-extensions.md](references/widgets-extensions.md): Widget sizes, App Clips design, Live Activities
-- [system-integration.md](references/system-integration.md): Siri, Shortcuts, Handoff, drag-drop, universal links
+The eight framework sections above each link their deep-dive reference inline at the point of need. Three further references cover system surfaces that sit outside the on-screen UI:
+
+- See [references/privacy-permissions.md](references/privacy-permissions.md) when the app requests camera, location, contacts, or any protected resource---request timing, pre-permission priming screens, usage-string wording, and the denied-permission recovery path.
+- See [references/widgets-extensions.md](references/widgets-extensions.md) when building a Home Screen widget, App Clip, Live Activity, or share/action extension---supported sizes and per-surface design constraints.
+- See [references/system-integration.md](references/system-integration.md) when wiring the app into the OS---Siri/Shortcuts intents, Handoff, drag-and-drop, universal links, and Spotlight indexing.
 
 ## Further Reading
 

--- a/ios-hig-design/references/colors-depth.md
+++ b/ios-hig-design/references/colors-depth.md
@@ -1,41 +1,30 @@
-# iOS Colors & Theming
+# iOS Colors & Theming Reference
 
-## Semantic Colors
+SKILL.md section 3 covers the core semantic palette (`label`, `secondaryLabel`, `systemBackground`, `systemBlue`/`systemRed`/`systemGreen`) and the three Dark Mode adaptation rules. This file adds what it does not carry: the extra layering tokens and the full WCAG contrast table.
 
-Use semantic colors that automatically adapt to light/dark mode:
+## Extra Semantic Tokens (beyond the core set)
 
-```swift
-Color(.label)              // Primary text
-Color(.secondaryLabel)     // Secondary text
-Color(.tertiaryLabel)      // Tertiary text
-Color(.systemBackground)   // Primary background
-Color(.secondarySystemBackground)  // Elevated/grouped
-Color(.systemBlue)         // Default tint/accent
-Color(.systemRed)          // Destructive actions
-Color(.systemGreen)        // Success/confirmation
-```
-
-## Dark Mode Guidelines
-
-1. **Text**: Invert colors (dark → light)
-2. **Backgrounds**: Shift darker while maintaining relative hierarchy
-3. **Accent colors**: Adjust to pop against dark backgrounds (often lower brightness, higher saturation)
+For multi-level hierarchy and grouped layouts, reach past the core six:
 
 ```swift
-// Preview both modes during development
-struct ContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        ContentView()
-            .preferredColorScheme(.light)
-        ContentView()
-            .preferredColorScheme(.dark)
-    }
-}
+Color(.tertiaryLabel)              // 3rd-level text (placeholders, disabled)
+Color(.quaternaryLabel)            // 4th-level (separators, faint glyphs)
+Color(.secondarySystemBackground)  // elevated cards / grouped table sections
+Color(.tertiarySystemBackground)   // a layer above secondary
+Color(.systemGroupedBackground)    // base behind grouped lists (Settings style)
+Color(.separator)                  // hairline dividers (already mode-aware)
 ```
 
-## Color Contrast
+Use the grouped-background family for `.insetGrouped` lists; use the plain `systemBackground` family for full-bleed content.
 
-Minimum contrast ratios (WCAG):
-- **4.5:1** for normal text
-- **3:1** for large text (18pt+ or 14pt+ bold)
-- **3:1** for UI components
+## Color Contrast (full WCAG table)
+
+SKILL.md states the 4.5:1 floor for body text. The complete set of minimums:
+
+| Content | Minimum ratio |
+|---------|---------------|
+| Normal text (< 18pt, or < 14pt bold) | 4.5:1 |
+| Large text (>= 18pt, or >= 14pt bold) | 3:1 |
+| UI components and graphical objects (icons, control borders, focus rings) | 3:1 |
+
+Verify with Xcode's Accessibility Inspector color contrast check, in both light and dark modes and with Increase Contrast enabled.

--- a/ios-hig-design/references/navigation.md
+++ b/ios-hig-design/references/navigation.md
@@ -8,7 +8,7 @@ The tab bar provides access to main app destinations.
 - **Items**: 2-5 tabs maximum
 - **Overflow**: Use "More" tab if >5 destinations needed
 - **Selected state**: Fill color indicates active tab
-- **Labels**: 10-11pt SF text
+- **Labels**: 10pt SF text
 - **Background**: Slightly translucent with background blur ("frosted glass")
 
 **Behavior**:

--- a/ios-hig-design/references/typography.md
+++ b/ios-hig-design/references/typography.md
@@ -1,44 +1,34 @@
-# iOS Typography Guidelines
+# iOS Typography Reference
+
+SKILL.md section 2 covers the sizes, weights, and the six type rules (min 11pt, 1.3x line height, 35-50 chars, left-aligned, weight-over-size, 4.5:1). This file adds what it does not carry: exact light-mode color values and the Dark Mode color mapping.
 
 ## System Font: San Francisco
 
-iOS uses San Francisco (SF Pro) as the default typeface. Use system text styles for automatic Dynamic Type support.
+iOS uses San Francisco (SF Pro) as the default typeface. Always reach the styles through semantic APIs (`.font(.title)`, `.font(.body)`, `.font(.caption)`) so Dynamic Type scaling and these colors apply automatically — never hardcode the point sizes or hex values below.
 
-## Standard Text Styles
+## Light-Mode Color Values
 
-| Element | Size | Weight | Color |
-|---------|------|--------|-------|
-| Large Title (unscrolled) | 34pt | Bold | #000000 |
-| Title (scrolled) | 17pt | Medium | #000000 |
-| Body text, List items | 17pt | Regular | #000000 |
-| Secondary text | 15pt | Regular | #3C3C43 @ 60% |
-| Caption, Tertiary | 12-13pt | Regular | #3C3C43 @ 60% |
-| Tab bar labels | 10pt | Regular | #8A8A8E |
+The point sizes live in SKILL.md; these are the hex values iOS resolves each semantic style to in light mode.
 
-## Typography Rules
-
-1. **Minimum text size**: 11pt (for captions/secondary info)
-2. **Line height**: Minimum 1.3× font size for paragraphs
-3. **Line length**: 35-50 characters per line for mobile
-4. **Alignment**: Left-aligned, non-justified text
-5. **Hierarchy**: Use weight and color variation, not size extremes
-6. **Contrast**: Minimum 4.5:1 ratio (WCAG AA standard)
+| Element | Semantic style | Color (light) |
+|---------|----------------|---------------|
+| Large Title / Title / Body | `.largeTitle` `.title` `.body` | `#000000` (label) |
+| Secondary text | `.subheadline` + `.secondary` | `#3C3C43` @ 60% (secondaryLabel) |
+| Caption / Tertiary | `.caption` + `.secondary` | `#3C3C43` @ 60% |
+| Tab bar labels (unselected) | 10pt | `#8A8A8E` (tertiaryLabel) |
 
 ```swift
-// Use semantic text styles for Dynamic Type support
-Text("Title")
-    .font(.title)
-
-Text("Body content")
-    .font(.body)
-
 Text("Caption")
     .font(.caption)
-    .foregroundColor(.secondary)
+    .foregroundColor(.secondary)   // resolves to secondaryLabel in both modes
 ```
 
-## Dark Mode Typography
+## Dark Mode Color Mapping
 
-- Black text (#000) → White (#FFF)
-- Dark gray text → Light gray text
-- Background colors shift darker (maintain relative hierarchy)
+Semantic styles flip automatically; this is the mapping they apply so you can verify a custom color matches it:
+
+- Primary text `#000000` -> `#FFFFFF` (label)
+- Secondary/tertiary gray -> lighter gray at the same opacity (secondaryLabel/tertiaryLabel)
+- Backgrounds shift darker while preserving the relative hierarchy between layers
+
+If you define a custom text color, put light/dark variants in the Asset Catalog so it follows this mapping instead of staying fixed.

--- a/jobs-to-be-done/SKILL.md
+++ b/jobs-to-be-done/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: jobs-to-be-done
-description: 'Discover what customers truly need by analyzing the "job" they hire your product to do. Use when the user mentions "customer discovery", "why customers churn", "what job does this solve", "competing against luck", "product-market fit", "switching behavior", "milkshake moment", "functional vs emotional jobs", "why do customers actually buy", or "understand what customers really need". Also trigger when investigating why users choose competitors, designing features around real customer needs, or reframing a value proposition. Covers JTBD interviews, competition analysis, and jobs-oriented roadmaps. For product positioning, see obviously-awesome. For rapid validation, see design-sprint.'
+description: 'Discover what customers truly need by analyzing the "job" they hire your product to do. Use when the user mentions "customer discovery", "why customers churn", "what job does this solve", "competing against luck", "product-market fit", "switching behavior", "milkshake moment", or "functional vs emotional jobs". Also trigger when investigating why users choose competitors, designing features around real customer needs, or reframing a value proposition. Covers JTBD interviews, competition analysis, and jobs-oriented roadmaps. For product positioning, see obviously-awesome. For rapid validation, see design-sprint. For non-leading interview technique, see mom-test.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Jobs to Be Done Framework
@@ -22,7 +22,7 @@ Key elements of the definition:
 
 ## Scoring
 
-**Goal: 10/10.** Rate product strategy or positioning 0-10 against the principles below. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score 1 point per satisfied row in the Quick Diagnostic (7 rows) plus up to 3 points for depth: +1 if all three job dimensions are evidenced, +1 if the job statement avoids any product/solution name, +1 if competition includes non-consumption. Bands: **9-10** = job stated without the product, all four forces mapped, three dimensions evidenced, non-obvious competition and Little Hire tracked; **5-6** = job named but one or two diagnostic rows fail (usually missing forces or emotional/social dimensions); **<=3** = product-first framing, demographic segmentation, or Pull-only thinking. Always state the current score and the specific diagnostic rows to fix.
 
 ## Three Dimensions of Every Job
 
@@ -40,7 +40,7 @@ Every job has three inseparable dimensions -- omitting any means failure:
 
 **Core concept:** A job statement captures the progress a customer seeks in a specific circumstance, in a structured format separating context, desired progress, and expected outcome.
 
-**Why it works:** Forcing teams to articulate the job in the customer's language and circumstances prevents solution-first thinking and grounds innovation in real human progress.
+**Why it works:** Because jobs are stable while solutions churn, anchoring on the job protects a roadmap from chasing features that the next technology shift makes irrelevant.
 
 **Key insights:**
 - Format: "When [circumstances], I want to [progress], so I can [outcome]"
@@ -61,9 +61,7 @@ Every job has three inseparable dimensions -- omitting any means failure:
 - Lead with the situation the customer recognizes, not the product category
 - Mirror the emotional and social dimensions alongside the functional one
 
-**Ethical boundary:** Never fabricate or exaggerate circumstances to manufacture urgency -- the job must reflect genuine progress, not artificial anxiety.
-
-See: [references/innovation-process.md](references/innovation-process.md) for job hunting methodology, the job atlas, and statement templates.
+See [references/innovation-process.md](references/innovation-process.md) when running an innovation project end-to-end -- the job-hunting methodology, the job atlas, and fill-in statement templates.
 
 ### 2. Forces of Progress (Push, Pull, Anxiety, Habit)
 
@@ -89,9 +87,7 @@ See: [references/innovation-process.md](references/innovation-process.md) for jo
 - Name the push: "Tired of [frustration]? There's a better way"
 - Reduce habit friction: "Switch in 5 minutes -- we import everything automatically"
 
-**Ethical boundary:** Reducing real anxiety is ethical; manufacturing fear or exaggerated pain to drive sales is manipulation.
-
-See: [references/competitive-strategy.md](references/competitive-strategy.md) for forces analysis, non-obvious competition, and jobs-based positioning.
+See [references/competitive-strategy.md](references/competitive-strategy.md) when mapping competitors or writing positioning -- forces analysis, the non-obvious-competition tables, and the jobs-based positioning formula with worked examples.
 
 ### 3. The Big Hire & Little Hire
 
@@ -117,9 +113,7 @@ See: [references/competitive-strategy.md](references/competitive-strategy.md) fo
 - Little Hire copy sells ease: "One click and you're done"
 - Re-engagement copy addresses the failure: "We've made [specific friction] easier"
 
-**Ethical boundary:** Never use dark patterns that win the Big Hire (hidden fees, misleading trials) while failing the Little Hire -- both decisions must deliver genuine progress.
-
-See: [references/case-studies.md](references/case-studies.md) for detailed analyses (SNHU, American Girl, Intuit).
+See [references/case-studies.md](references/case-studies.md) when you need a worked precedent to reason from -- full Big Hire / Little Hire breakdowns of SNHU, American Girl, and Intuit.
 
 ### 4. Competitive Landscape (Non-Obvious Competition)
 
@@ -146,8 +140,6 @@ See: [references/case-studies.md](references/case-studies.md) for detailed analy
 - "You wouldn't hire a [bad fit] to [job] -- so why are you using [current hack]?"
 - Position around the job outcome, not feature comparison charts
 
-**Ethical boundary:** Honest competitive framing based on the job is powerful; misrepresenting alternatives is deceptive.
-
 ### 5. Customer Discovery Interviews
 
 **Core concept:** Don't ask customers "what do you need" -- they don't know. Instead, reconstruct the purchase timeline (first thought, search, purchase, usage) to uncover the real job.
@@ -160,6 +152,7 @@ See: [references/case-studies.md](references/case-studies.md) for detailed analy
 - Purchase: "Where were you? What ultimately convinced you? What were you afraid of?"
 - Usage: "Is it doing what you expected? What surprised you? What's still missing?"
 - Signals of undiscovered jobs: workarounds, non-consumption, compensating behaviors, negative emotions toward current solutions
+- Ask only about past events, never hypotheticals ("would you...", "do you wish...") -- a question that names your solution or a benefit leads the subject and produces confirmation, not discovery
 
 **Product applications:**
 
@@ -173,8 +166,6 @@ See: [references/case-studies.md](references/case-studies.md) for detailed analy
 - Use exact customer language from interviews in marketing copy
 - "We heard you say [verbatim quote] -- so we built [feature]"
 - Frame benefits in the circumstances and emotions customers actually described
-
-**Ethical boundary:** Never lead interview subjects toward predetermined conclusions -- the goal is discovery, not confirmation.
 
 ### 6. Designing for the Job
 
@@ -200,9 +191,7 @@ See: [references/case-studies.md](references/case-studies.md) for detailed analy
 - "Everything you need to [job] -- nothing you don't"
 - Emphasize outcome and progress, not features and specifications
 
-**Ethical boundary:** Never design addictive patterns that serve engagement metrics over genuine progress -- the customer's progress is the true north, not your retention numbers.
-
-See: [references/organizational-change.md](references/organizational-change.md) for the feature-factory trap, executive buy-in, and change management.
+See [references/organizational-change.md](references/organizational-change.md) when adoption is the bottleneck rather than the analysis -- escaping the feature-factory trap, winning executive buy-in, and managing the change.
 
 ## Common Mistakes
 
@@ -228,15 +217,7 @@ See: [references/organizational-change.md](references/organizational-change.md) 
 | Can your team explain how each feature serves the job? | Building without strategic grounding | Require proposals to name the job dimension served |
 | Have you interviewed customers about their purchase timeline? | Job understanding based on assumptions | Run 10+ interviews reconstructing first-thought-to-usage |
 
-See: [references/diagnostics.md](references/diagnostics.md) for the full diagnostic checklist.
-
-## Reference Files
-
-- [innovation-process.md](references/innovation-process.md): Job hunting methodology, job atlas, prototype testing, job statements
-- [competitive-strategy.md](references/competitive-strategy.md): Non-obvious competition, jobs-based positioning, pricing strategy
-- [organizational-change.md](references/organizational-change.md): Overcoming objections, feature-factory trap, executive buy-in, change management
-- [diagnostics.md](references/diagnostics.md): Diagnostic checklist for evaluating products through the jobs lens
-- [case-studies.md](references/case-studies.md): Detailed analyses of SNHU, American Girl, Intuit, and more
+When the inline Quick Diagnostic above is not enough -- you are diagnosing a *symptom* (low signups, high churn, "used wrong") or need JTBD-specific metrics -- see [references/diagnostics.md](references/diagnostics.md): the "why aren't they buying" symptom table, churn-pattern tables, and traditional-vs-JTBD metric swaps.
 
 ## Further Reading
 

--- a/jobs-to-be-done/references/diagnostics.md
+++ b/jobs-to-be-done/references/diagnostics.md
@@ -1,27 +1,6 @@
 # Product Diagnostics Through JTBD Lens
 
-## Checklist: Do You Know Your Product's Job?
-
-### Level 1: Basic Understanding
-
-- [ ] You can describe the job in one sentence without using the product name
-- [ ] You know the circumstances in which the job arises
-- [ ] You know what customer did BEFORE using your product
-- [ ] You understand the functional, emotional, AND social dimensions
-
-### Level 2: Deep Understanding
-
-- [ ] You know what you really compete with (not just "direct competitors")
-- [ ] You understand push/pull and habit/anxiety forces for your customer
-- [ ] You can distinguish Big Hire from Little Hire
-- [ ] You know why customers "fire" your product
-
-### Level 3: Organizational Implementation
-
-- [ ] Product decisions are filtered through the job lens
-- [ ] Metrics measure job completion, not just usage
-- [ ] Roadmap is oriented toward better job execution
-- [ ] Team can articulate the customer's job
+This file is the deep diagnostic layer behind SKILL.md. Run the **Quick Diagnostic** table in SKILL.md first for the seven pass/fail readiness checks; come here when a symptom needs a probable cause, when you need JTBD metrics, or when you are running a churn analysis.
 
 ## Red Flags - Signs You Don't Know the Job
 
@@ -43,26 +22,7 @@
 | They buy but don't use | Little Hire lost | Redesign the moment of use |
 | They use but churn | Job changed or better "employee" appeared | Investigate "firing" reasons |
 
-### "Firing" Interview (Churn Interview)
-
-Questions for customers who left:
-
-1. "What did you do before us? Why did you come to us?"
-2. "What changed that made you start looking for alternatives?"
-3. "What ultimately convinced you to leave?"
-4. "What do you do now instead of us? Does it do the job better?"
-5. "If we could change one thing, what would it be?"
-
-### "Hiring" Interview (New Customer Interview)
-
-Questions for new customers (within 2 weeks):
-
-1. "When did you first think about looking for a solution?"
-2. "What was the trigger - what was happening then?"
-3. "What alternatives did you look for? What disqualified them?"
-4. "What ultimately convinced you to choose us?"
-5. "What were you afraid of before buying?"
-6. "Is the product doing what you expected?"
+For the full timeline-interview question set (first-thought -> search -> purchase -> usage), see SKILL.md section 5; for the structured churn ("firing") interview, see the Churn Interview Framework table below.
 
 ## JTBD Metrics
 

--- a/lean-analytics/SKILL.md
+++ b/lean-analytics/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: lean-analytics
-description: 'Choose and audit startup metrics using Croll and Yoskovitz''s "Lean Analytics". Use when the user mentions "what metrics should we track", "KPIs", "north star metric", "One Metric That Matters", "OMTM", "vanity metrics", "analytics dashboard", "DAU/MAU", "churn benchmark", "measure product-market fit", "are we tracking the right things", or "which number actually matters". Also trigger when choosing metrics for a startup or feature, auditing a dashboard for vanity metrics, setting metric targets and baselines, or instrumenting a product by business model and stage. Covers good-vs-vanity metrics, the One Metric That Matters, metrics by business model, the five startup stages, and benchmarks. For the build-measure-learn loop, see lean-startup. For fixing activation and retention, see improve-retention.'
+description: 'Choose and audit startup metrics using Croll and Yoskovitz''s "Lean Analytics". Use when the user mentions "what metrics should we track", "KPIs", "north star metric", "One Metric That Matters (OMTM)", "vanity metrics", "analytics dashboard", "DAU/MAU", "churn benchmark", or "measure product-market fit". Also trigger when choosing metrics for a startup or feature, auditing a dashboard for vanity metrics, setting metric targets and baselines, or instrumenting a product by business model and stage. Covers good-vs-vanity metrics, the One Metric That Matters, metrics by business model, the five startup stages, and benchmarks. For the build-measure-learn loop, see lean-startup. For fixing activation and retention, see improve-retention.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Lean Analytics
@@ -49,9 +49,7 @@ A data discipline for startups distilled from Alistair Croll and Benjamin Yoskov
 | Board reporting | Show cohorts, not cumulative curves | Retention by signup month replaces "users over time" |
 | Feature decision | Demand a behavior-changing metric | "If D7 retention doesn't rise 10%, the feature comes out" |
 
-**Ethical boundary:** Metrics exist to describe and serve users, not manipulate them — instrument only what you need and respect privacy in what you collect.
-
-See: [references/good-metrics.md](references/good-metrics.md)
+See references/good-metrics.md when auditing a dashboard or running a metric through the four tests — full test definitions, the 10-row vanity rewrite table, a worked cohort-retention example, segmentation rules, the correlation-to-causation experiment loop, and a metric-definition template.
 
 ### 2. The One Metric That Matters (OMTM)
 
@@ -77,7 +75,7 @@ See: [references/good-metrics.md](references/good-metrics.md)
 
 **Ethical boundary:** The line in the sand disciplines the company's bets, not individuals — turning the OMTM into personal quotas invites gaming and hides truth.
 
-See: [references/omtm.md](references/omtm.md)
+See references/omtm.md when choosing or rotating the OMTM, pairing a counter-metric, or drawing the line in the sand — the six-step selection procedure, the 6x3 stage x model matrix, a 7-row counter-metric gaming table, line-in-the-sand and rotation-trigger rules, and three worked examples.
 
 ### 3. Metrics by Business Model
 
@@ -101,7 +99,7 @@ See: [references/omtm.md](references/omtm.md)
 | North-star debate | Derive from model mechanics, don't copy | Marketplace adopts fill rate, not a SaaS-style MRR target |
 | Investor dashboard | Report the model's canonical ratios | SaaS deck: MRR growth, net churn, LTV:CAC, CAC payback |
 
-See: [references/business-model-metrics.md](references/business-model-metrics.md)
+See references/business-model-metrics.md when instrumenting a product or picking a model's canonical ratios — metric trees for all six models with formulas, instrumentation notes, measurement failure modes, and hybrid-model guidance.
 
 ### 4. Metrics by Stage: The Lean Analytics Stages
 
@@ -125,7 +123,7 @@ See: [references/business-model-metrics.md](references/business-model-metrics.md
 | Roadmap prioritization | Stage picks the OMTM; OMTM picks the work | Stickiness stage ships onboarding fixes, not a referral program |
 | Fundraising narrative | Pitch the passed gate and its evidence | "Week-4 retention flat at 35% — raising to scale acquisition" |
 
-See: [references/five-stages.md](references/five-stages.md)
+See references/five-stages.md when locating your stage or deciding whether you've passed a gate — the per-stage playbook with gating metrics, exit-criteria checklists, premature-scaling symptoms, and funding/runway interactions.
 
 ### 5. Baselines and Lines in the Sand
 
@@ -149,7 +147,7 @@ See: [references/five-stages.md](references/five-stages.md)
 | Anomaly triage | Compare to your own baseline before benchmarks | Conversion fell 2.4% → 1.9% in a week — investigate the release |
 | Channel evaluation | Re-derive benchmarks per channel | Paid social converts 0.8%, search 4% — budget follows the line |
 
-See: [references/case-studies.md](references/case-studies.md)
+See references/case-studies.md when you want a full worked walkthrough — three scenarios: SaaS dashboard to OMTM, marketplace liquidity discovery, and a mobile app fixing stickiness before growth.
 
 ## Common Mistakes
 
@@ -176,14 +174,6 @@ See: [references/case-studies.md](references/case-studies.md)
 | Is there a target with a date and a miss plan? | Goalposts will move after results | Draw the line in the sand in writing |
 | Is the data cohorted and segmented? | Averages are hiding the truth | Build cohort tables; split by channel and segment |
 | Is a counter-metric guarding the OMTM? | The OMTM will be gamed | Pair it, e.g. signup growth × 30-day retention |
-
-## Reference Files
-
-- [references/good-metrics.md](references/good-metrics.md) — Four tests of a good metric, vanity-metric rewrite table, cohort analysis how-to, segmentation discipline, correlation-to-causation loop, metric definition template
-- [references/omtm.md](references/omtm.md) — Choosing the OMTM step by step, stage × model matrix, counter-metric pairing, lines in the sand, dashboard design, rotation triggers, worked examples
-- [references/business-model-metrics.md](references/business-model-metrics.md) — Metric trees for all six business models with formulas, instrumentation notes, measurement failure modes, hybrid-model guidance
-- [references/five-stages.md](references/five-stages.md) — Stage-by-stage playbook: gating metrics, exit-criteria checklists, premature-scaling symptoms, funding and runway interactions
-- [references/case-studies.md](references/case-studies.md) — Three scenarios: SaaS dashboard to OMTM, marketplace liquidity discovery, mobile app fixing stickiness before growth
 
 ## Further Reading
 

--- a/lean-startup/SKILL.md
+++ b/lean-startup/SKILL.md
@@ -4,7 +4,7 @@ description: 'Design MVPs, validated learning experiments, and pivot-or-persever
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Lean Startup Methodology
@@ -13,13 +13,17 @@ A systematic approach to building startups and launching new products that short
 
 ## Core Principle
 
-**Entrepreneurship is a form of management.** Success doesn't require a perfect plan or brilliant insight—it requires a systematic process for testing assumptions, learning from customers, and iterating rapidly.
-
-**The foundation:** Most startups fail not because they couldn't build what they planned, but because they built the wrong thing. Lean Startup applies scientific experimentation to eliminate waste and accelerate validated learning.
+**Entrepreneurship is a form of management.** Success doesn't require a perfect plan or brilliant insight—it requires a systematic process for testing assumptions, learning from customers, and iterating rapidly. Most startups fail not because they couldn't build what they planned, but because they built the wrong thing: treat every plan as a set of hypotheses to falsify, and spend effort to eliminate waste and accelerate **validated learning**, not to execute a fixed roadmap.
 
 ## Scoring
 
-**Goal: 10/10.** Rate product development plans, experiments, or metrics 0-10 against Lean Startup principles: full Build-Measure-Learn application and evidence-based decisions score 10; waterfall thinking or waste lowers the score. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score a plan, experiment, or metric set by the five Quick Diagnostic rows—**1 point each** when the answer is yes, **2 points** when it is also backed by evidence on the Validation Ladder (Level 3+):
+
+- **9-10:** every leap-of-faith assumption named and ranked by risk, the riskiest tested by a real MVP, actionable metrics defined, and explicit pivot criteria set before building.
+- **5-6:** a hypothesis and some MVP exist, but metrics are vanity or pivot criteria are undefined—decisions can't be made from the data.
+- **≤3:** waterfall thinking—building the full product first, asking customers what they want, or scaling before product/market fit.
+
+State the current score and the lowest-scoring diagnostic row to fix next.
 
 ## The Build-Measure-Learn Loop
 
@@ -32,7 +36,7 @@ The fundamental cycle: **IDEAS → BUILD (product) → MEASURE (data) → LEARN 
 
 **Goal:** Minimize total time through the loop.
 
-See: [references/build-measure-learn.md](references/build-measure-learn.md) for detailed loop execution and reverse planning.
+See [references/build-measure-learn.md](references/build-measure-learn.md) when planning an experiment—reverse-planning sequence, an experiment-design template, per-product-type loop examples, and the build/vanity-metric loop traps.
 
 ## Validated Learning
 
@@ -66,7 +70,7 @@ The version of a new product that allows maximum validated learning with the lea
 
 **Design questions:** What's the riskiest assumption? What's the minimum that tests it? How do we measure whether it was validated?
 
-See: [references/mvp-design.md](references/mvp-design.md) for MVP types, design patterns, and sizing.
+See [references/mvp-design.md](references/mvp-design.md) when choosing and sizing an MVP—seven types in depth, a type-selection decision matrix, lower/upper sizing bounds, and the MVP Design Canvas.
 
 ## Leap-of-Faith Assumptions
 
@@ -81,7 +85,7 @@ The assumptions that, if wrong, will cause your business to fail. Identify them,
 
 **Example—Dropbox:** Leap of faith: "people will download and use a file sync tool." Test: explainer video before building scale infrastructure. Result: beta list grew from 5,000 to 75,000 overnight—demand validated.
 
-See: [references/assumptions.md](references/assumptions.md) for assumption mapping frameworks.
+See [references/assumptions.md](references/assumptions.md) when mapping and ranking assumptions—the Impact-Uncertainty matrix, a prioritization scoring template, test methods per assumption type, and industry-specific assumption lists.
 
 ## Innovation Accounting
 
@@ -97,9 +101,9 @@ Run experiments to improve baseline metrics: A/B test pricing ($9 vs. $19/mo), o
 
 ### 3. Pivot or Persevere
 
-Decide from evidence: Are metrics moving the right way? Is the rate of improvement acceptable given the runway? Are we learning what we expected?
+When tuning stalls, make the evidence-based call (criteria and pivot types below in **Pivot or Persevere**).
 
-See: [references/innovation-accounting.md](references/innovation-accounting.md) for metric frameworks and dashboards.
+See [references/innovation-accounting.md](references/innovation-accounting.md) when building the baseline dashboard—funnel, cohort, and economics metric frameworks.
 
 ## Actionable vs. Vanity Metrics
 
@@ -119,7 +123,7 @@ Vanity metrics make you feel good but don't change behavior; actionable metrics 
 
 **Cohort analysis:** Group users by signup date and track behavior over time—the only way to see whether the product is actually improving.
 
-See: [references/metrics.md](references/metrics.md) for metric selection and tracking.
+See [references/metrics.md](references/metrics.md) when building a cohort table or choosing what to track—a five-step cohort walkthrough and AARRR (Pirate Metrics) aligned with Lean Startup stages.
 
 ## Pivot or Persevere
 
@@ -144,7 +148,7 @@ A pivot is a structured course correction designed to test a new hypothesis abou
 
 **Cadence:** Successful startups commonly pivot 1-5 times before product-market fit. **Anti-pattern:** "pivoting" without validating that the new direction solves the core problem.
 
-See: [references/pivots.md](references/pivots.md) for pivot decision frameworks and case studies.
+See [references/pivots.md](references/pivots.md) when the data suggests a pivot—the data-driven pivot signals, a structured pivot-meeting agenda, leading indicators, and the Instagram/Slack/YouTube pivot stories.
 
 ## The Three Engines of Growth
 
@@ -162,7 +166,7 @@ Customers bring customers: `viral coefficient = (% who invite) × (invites sent)
 
 Spend to acquire: requires `LTV > CAC` (target LTV/CAC > 3x). Track CAC, LTV, and payback period. Fits e-commerce and traditional businesses. Strategy: optimize until each customer's profit funds acquiring more.
 
-See: [references/growth-engines.md](references/growth-engines.md) for engine selection and optimization.
+See [references/growth-engines.md](references/growth-engines.md) when picking or tuning an engine—churn-reduction tactics, the K-factor and viral-loop design, LTV/CAC optimization, a channel-economics table, and the product-to-engine matching framework.
 
 ## The Five Whys
 
@@ -177,7 +181,7 @@ Root cause analysis: when a problem occurs, ask "why?" five times, then invest p
 
 **Proportional investments:** fix the bug (1), add memory monitoring (2), implement code review (3-4), slow down to build quality processes (5). **Anti-pattern:** stopping at level 1.
 
-See: [references/five-whys.md](references/five-whys.md) for facilitation guides.
+See [references/five-whys.md](references/five-whys.md) when facilitating a session—three worked examples (outage, churn spike, launch failure) and how to handle diverging chains, blame creep, and root causes outside your control.
 
 ## Small Batches
 
@@ -192,7 +196,7 @@ Work in small batches for faster feedback loops, easier pivots, less waste when 
 
 **Continuous deployment** is the ultimate small batch: deploy every commit, catch bugs immediately, learn continuously, reduce risk per release.
 
-See: [references/small-batches.md](references/small-batches.md) for implementation patterns.
+See [references/small-batches.md](references/small-batches.md) when setting up faster release cadence—the continuous-deployment pipeline and prerequisites, feature-flag types, a progressive-rollout checklist, and work-decomposition techniques.
 
 ## Lean Startup Applied: From Idea to Scale
 
@@ -207,7 +211,7 @@ See: [references/small-batches.md](references/small-batches.md) for implementati
 - **Corporate innovation:** separate innovation accounting from core-business metrics, shield teams from quarterly revenue pressure, unlock metered funding on validated-learning milestones
 - **Product features:** deploy behind a feature flag → A/B test against core metrics → kill, iterate, or scale based on data
 
-See: [references/applications.md](references/applications.md) for context-specific guides.
+See [references/applications.md](references/applications.md) for context-specific playbooks (SaaS, corporate innovation, features), and [references/case-studies.md](references/case-studies.md) for the full Dropbox, IMVU, Zappos, and Groupon stories—including failures—when you want a worked precedent for the bet in front of you.
 
 ## Common Mistakes
 
@@ -232,20 +236,6 @@ Audit any product development plan:
 | What metric will validate/invalidate? | You won't learn | Define actionable metrics |
 | Can you test with less than this? | Over-building | Shrink the MVP further |
 | What will you do if the experiment fails? | No pivot criteria | Define pivot triggers upfront |
-
-## Reference Files
-
-- [build-measure-learn.md](references/build-measure-learn.md): Detailed loop execution, reverse planning
-- [mvp-design.md](references/mvp-design.md): MVP types, design patterns, sizing
-- [assumptions.md](references/assumptions.md): Leap-of-faith assumption mapping
-- [innovation-accounting.md](references/innovation-accounting.md): Metric frameworks, dashboards
-- [metrics.md](references/metrics.md): Actionable vs. vanity, cohort analysis, metric selection
-- [pivots.md](references/pivots.md): Pivot types, decision frameworks, case studies
-- [growth-engines.md](references/growth-engines.md): Sticky, viral, paid engines in depth
-- [five-whys.md](references/five-whys.md): Root cause analysis, facilitation guides
-- [small-batches.md](references/small-batches.md): Batch size reduction, continuous deployment
-- [applications.md](references/applications.md): SaaS, corporate innovation, features
-- [case-studies.md](references/case-studies.md): Dropbox, IMVU, Zappos, Groupon, and failures
 
 ## Further Reading
 

--- a/lean-ux/SKILL.md
+++ b/lean-ux/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: lean-ux
-description: 'Apply lean thinking to UX: hypothesis-driven design, collaborative sketching, and rapid experiments instead of heavy deliverables. Use when the user mentions "Lean UX", "design hypothesis", "UX experiment", "collaborative design", "outcome over output", "design studio method", "assumption mapping", "lightweight research", "too much design documentation", "design faster as a team", or "get the team designing together". Also trigger when reducing design-documentation overhead, getting cross-functional teams to co-design, or running fast usability experiments. Covers hypothesis statements, MVPs for UX, and cross-functional collaboration. For Build-Measure-Learn, see lean-startup. For usability audits, see ux-heuristics.'
+description: 'Apply lean thinking to UX: hypothesis-driven design, collaborative sketching, and rapid experiments instead of heavy deliverables. Use when the user mentions "Lean UX", "design hypothesis", "outcome over output", "design studio method", "assumption mapping", "lightweight research", "too much design documentation", or "get the team designing together". Also trigger when reducing design-documentation overhead, getting cross-functional teams to co-design, or running fast usability experiments. Covers hypothesis statements, MVPs for UX, and cross-functional collaboration. For Build-Measure-Learn, see lean-startup. For usability audits, see ux-heuristics.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Lean UX Framework
@@ -19,7 +19,13 @@ A practice-driven approach to UX that replaces heavy deliverables with rapid exp
 
 ## Scoring
 
-**Goal: 10/10.** Rate UX processes, design plans, or team workflows 0-10 against Lean UX principles: hypothesis-driven design, minimal deliverables, collaborative practices, and outcome-focused metrics score high; heavy-deliverable thinking or untested assumptions lower the score. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score a UX process, design plan, or team workflow by the eight-row Quick Diagnostic below: award ~1.25 points per row answered "yes" (8 yeses = 10). Bands:
+
+- **9-10** — assumptions declared, hypotheses with pre-committed success criteria, lowest-fidelity experiments, whole-team design, weekly research, outcome (not output) metrics, dual-track agile, and a recently invalidated hypothesis on the books.
+- **5-6** — hypotheses exist but criteria are vague or fidelity is over-invested; design and research still partly siloed.
+- **<=3** — heavy deliverables, untested assumptions, output-counting, no experiment log.
+
+Always state the current score, the diagnostic rows that failed, and the specific fix for each.
 
 ## Framework
 
@@ -45,7 +51,7 @@ A practice-driven approach to UX that replaces heavy deliverables with rapid exp
 
 **Ethical boundary:** Assumptions must be honest assessments, not post-hoc justifications—if leadership has already committed to a direction, acknowledge the constraint rather than pretending it's open to falsification.
 
-See: [references/hypothesis-canvas.md](references/hypothesis-canvas.md) for the assumption prioritization matrix and hypothesis statement formats.
+See [references/hypothesis-canvas.md](references/hypothesis-canvas.md) when running an assumption workshop or writing a hypothesis — the risk/uncertainty prioritization matrix, business-vs-user assumption split, and fillable hypothesis and sub-hypothesis templates.
 
 ### 2. Hypothesis Statements
 
@@ -68,6 +74,8 @@ See: [references/hypothesis-canvas.md](references/hypothesis-canvas.md) for the 
 | **Sprint planning** | Attach hypothesis to each story | Story: "filter by date." Hypothesis: "task completion time drops 30%" |
 
 **Ethical boundary:** Never cherry-pick metrics after the fact to declare a hypothesis validated—pre-commit to success criteria.
+
+See [references/outcome-metrics.md](references/outcome-metrics.md) when picking the measurable signal for a hypothesis or defining team success — outcomes-vs-outputs, leading-vs-lagging indicator pairs, UX OKRs, and the vanity metrics to avoid.
 
 ### 3. MVPs and Experiments
 
@@ -92,7 +100,7 @@ See: [references/hypothesis-canvas.md](references/hypothesis-canvas.md) for the 
 
 **Ethical boundary:** Smoke tests and fake doors must not mislead users into believing a product exists—disclose test status and offer an opt-out.
 
-See: [references/experiment-patterns.md](references/experiment-patterns.md) for experiment types, selection guidance, and design templates.
+See [references/experiment-patterns.md](references/experiment-patterns.md) when choosing or designing an experiment — the full catalog of experiment types with when/when-NOT-to-run notes, the experiment selection matrix and fidelity ladder, and a design template.
 
 ### 4. Collaborative Design
 
@@ -116,13 +124,13 @@ See: [references/experiment-patterns.md](references/experiment-patterns.md) for 
 
 **Ethical boundary:** Collaboration must not become design by committee—a designated designer synthesizes input; the team does not vote on pixels.
 
-See: [references/collaborative-design.md](references/collaborative-design.md) for the Design Studio method and living style guides.
+See [references/collaborative-design.md](references/collaborative-design.md) when facilitating a Design Studio — the step-by-step workshop protocol (timings, materials, remote variants) and how to keep style guides as living documents.
 
 ### 5. Feedback and Research
 
 **Core concept:** Continuous, lightweight research replaces big-bang usability studies—small research activities embedded in every sprint instead of quarterly reports.
 
-**Why it works:** Feedback that arrives months after a design decision is too late to influence it; cheap, frequent research lets teams correct course incrementally.
+**Why it works:** Findings only change a decision while it is still cheap to reverse, so research value decays with every sprint between learning and the decision it informs; small weekly studies keep that gap near zero, which a quarterly report never can.
 
 **Key insights:**
 - Research types: usability tests, customer interviews, A/B tests, analytics review, surveys, diary studies
@@ -163,7 +171,9 @@ See: [references/collaborative-design.md](references/collaborative-design.md) fo
 
 **Ethical boundary:** Never use Lean UX as an excuse to skip accessibility, security, or compliance—these are non-negotiable quality standards, not assumptions to test.
 
-See: [references/agile-integration.md](references/agile-integration.md) for dual-track agile and staggered sprint mechanics.
+See [references/agile-integration.md](references/agile-integration.md) when fitting discovery into a delivery cadence — the staggered dual-track sprint mechanics, how stories carry a hypothesis, and a UX Definition of Done.
+
+See [references/case-studies.md](references/case-studies.md) when you want a worked end-to-end example to model an engagement on — four composite scenarios (enterprise, startup, agency, internal tools) showing assumptions, experiments, and before/after outcome metrics.
 
 ## Common Mistakes
 
@@ -192,15 +202,6 @@ Audit any UX process or design plan:
 | Are you tracking outcomes, not just outputs? | Shipping without learning | Define behavior-change metrics per feature |
 | Does UX work feed into Agile smoothly? | Design bottleneck or sprint-zero trap | Implement dual-track agile with staggered sprints |
 | Can you point to a recently invalidated hypothesis? | Not learning; confirmation bias | Review the experiment log and celebrate a pivot |
-
-## Reference Files
-
-- [hypothesis-canvas.md](references/hypothesis-canvas.md): Hypothesis statement format, assumption prioritization matrix, business vs. user assumptions, sub-hypotheses
-- [experiment-patterns.md](references/experiment-patterns.md): UX experiment types, choosing the right experiment, experiment design template, minimum viable tests
-- [collaborative-design.md](references/collaborative-design.md): Design Studio method, collaborative sketching, cross-functional design, living style guides
-- [agile-integration.md](references/agile-integration.md): Dual-track agile, fitting UX into sprints, staggered sprints, Definition of Done for UX
-- [outcome-metrics.md](references/outcome-metrics.md): Outcomes vs. outputs, leading vs. lagging indicators, OKRs for UX, vanity metrics to avoid
-- [case-studies.md](references/case-studies.md): Enterprise product team, startup, agency, and internal tools team scenarios
 
 ## Further Reading
 

--- a/made-to-stick/SKILL.md
+++ b/made-to-stick/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: made-to-stick
-description: 'Craft messages that are understood, remembered, and drive action using the SUCCESs checklist (Simple, Unexpected, Concrete, Credible, Emotional, Stories). Use when the user mentions "make it memorable", "sticky messaging", "tagline", "value proposition", "why the message isnt landing", "knowledge curse", "concrete language", "people forget our message", "make this stick", or "no one remembers our pitch". Also trigger when writing a pitch deck, simplifying a complex product explanation, or making a presentation more compelling and memorable. Covers the six SUCCESs traits and the curse of knowledge. For narrative brand frameworks, see storybrand-messaging. For viral sharing, see contagious.'
+description: 'Craft messages that are understood, remembered, and drive action using the SUCCESs checklist (Simple, Unexpected, Concrete, Credible, Emotional, Stories). Use when the user mentions "make it memorable", "no one remembers our pitch", "tagline", "value proposition", "why the message isnt landing", "curse of knowledge", or "concrete language". Also trigger when writing a pitch deck, simplifying a complex product explanation, or making a presentation more compelling. Covers the six SUCCESs traits and the curse of knowledge. For narrative brand frameworks, see storybrand-messaging. For viral sharing, see contagious.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Made to Stick Framework
@@ -17,13 +17,13 @@ A framework for crafting ideas and messages that are understood, remembered, and
 
 ## Scoring
 
-**Goal: 10/10.** Rate any messaging (copy, presentations, campaigns, onboarding) 0-10 against the SUCCESs principles: simple, surprising, concrete, credible, emotional, and wrapped in a story scores 10; forgettable communication scores low. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score any messaging (copy, presentations, campaigns, onboarding) by running the [Quick Diagnostic](#quick-diagnostic): rate each of the six traits 1-10, then map the 6-60 total to a band (50-60 = 9-10, extremely sticky; 35-49 = 7-8, strong; 20-34 = 4-6, forgettable; below 20 = ≤3, won't stick). Always state the current score, which traits scored lowest, and the specific fix from the diagnostic's Fix column.
 
 ## The SUCCESs Framework
 
 **S**imple · **U**nexpected · **C**oncrete · **C**redible · **E**motional · **S**tories
 
-**Not a checklist—a toolkit.** Not every sticky idea uses all six, but the stickiest ideas tend to use most of them. **Ethical boundary:** use SUCCESs to make true ideas stick—never to make false claims memorable.
+**Not a checklist—a toolkit.** Not every sticky idea uses all six, but the stickiest ideas tend to use most of them—don't force all six onto a message that only needs two.
 
 ### 1. Simple
 
@@ -49,7 +49,7 @@ A framework for crafting ideas and messages that are understood, remembered, and
 
 **The test:** Can you explain it to a smart 12-year-old? **Warning:** don't simplify into emptiness—"we make the world better" is simple but meaningless.
 
-See: [references/simple.md](references/simple.md) for simplification exercises and templates.
+See [references/simple.md](references/simple.md) when you can't reduce a message to one core idea—it has the Commander's Intent exercise, the inverted-pyramid pattern, and five "find the core" drills.
 
 ### 2. Unexpected
 
@@ -74,7 +74,7 @@ See: [references/simple.md](references/simple.md) for simplification exercises a
 
 **Anti-pattern:** Gimmicky surprise without substance.
 
-See: [references/unexpected.md](references/unexpected.md) for pattern-breaking techniques.
+See [references/unexpected.md](references/unexpected.md) when a message reads as predictable—it has techniques for finding the counterintuitive angle and engineering curiosity gaps.
 
 ### 3. Concrete
 
@@ -103,7 +103,7 @@ See: [references/unexpected.md](references/unexpected.md) for pattern-breaking t
 
 **Application:** features → outcomes; percentages → real numbers ("saves 40%" → "saves 16 hours/month"); categories → specific examples ("restaurants" → "pizza shops in Brooklyn"); demos > feature lists.
 
-See: [references/concrete.md](references/concrete.md) for concreteness exercises.
+See [references/concrete.md](references/concrete.md) when a message stays abstract—it has sensory-language drills and the abstract-to-concrete conversion process.
 
 ### 4. Credible
 
@@ -130,7 +130,7 @@ See: [references/concrete.md](references/concrete.md) for concreteness exercises
 
 **Making statistics stick:** put them in a context people understand—not "37 grams of saturated fat" but "more saturated fat than a Big Mac, fries, and milkshake combined."
 
-See: [references/credible.md](references/credible.md) for credibility-building techniques.
+See [references/credible.md](references/credible.md) when a claim sounds unbelievable—it has authority types, the Sinatra Test, and methods for making statistics human-scale.
 
 ### 5. Emotional
 
@@ -155,7 +155,7 @@ See: [references/credible.md](references/credible.md) for credibility-building t
 
 **Avoid the "semantic stretch":** don't over-abstract the emotion—"Support the troops" beats "Support our national defense infrastructure."
 
-See: [references/emotional.md](references/emotional.md) for emotional appeal frameworks.
+See [references/emotional.md](references/emotional.md) when a message is all logic and no feeling—it has the individual-focus, identity, and self-interest appeal frameworks.
 
 ### 6. Stories
 
@@ -176,7 +176,7 @@ See: [references/emotional.md](references/emotional.md) for emotional appeal fra
 
 **Spotting stories in the wild:** support tickets (problems + resolutions), sales calls (objections + breakthroughs), user interviews (before/after moments), internal Slack (team wins).
 
-See: [references/stories.md](references/stories.md) for story templates and collection methods.
+See [references/stories.md](references/stories.md) when you need to build a narrative—it has the three story plots, the product-story structure, and methods for collecting real stories.
 
 ## The Curse of Knowledge
 
@@ -184,22 +184,7 @@ See: [references/stories.md](references/stories.md) for story templates and coll
 
 **Solutions:** test messaging with outsiders (not your team); use concrete language, not abstractions; tell stories, not bullet points; ask "would my mom understand this?"
 
-See: [references/curse-of-knowledge.md](references/curse-of-knowledge.md) for diagnosis and remedies.
-
-## Sticky Messaging Audit
-
-Rate your message on each principle:
-
-| Principle | Question | Score (1-10) |
-|-----------|----------|-------------|
-| **Simple** | Is there ONE clear core message? | |
-| **Unexpected** | Does it break a pattern or create curiosity? | |
-| **Concrete** | Can you picture it? Are there specific details? | |
-| **Credible** | Why should someone believe this? | |
-| **Emotional** | Does it make you feel something? | |
-| **Stories** | Is there a narrative or character? | |
-
-**Scoring:** 50-60 extremely sticky (rare, aim for this) · 35-49 strong (most good messaging) · 20-34 average (forgettable, needs work) · below 20 won't stick (fundamental rework).
+See [references/curse-of-knowledge.md](references/curse-of-knowledge.md) when your own message reads clearly but lands flat on others—it has diagnosis and remedies for shared-context blind spots.
 
 ## Applying SUCCESs to Product
 
@@ -224,7 +209,7 @@ Rate your message on each principle:
 - **Credible:** "Join 5,000 teams already using..."
 - **Emotional + Stories:** celebrate first success; "here's how [user] got started..."
 
-See: [references/applications.md](references/applications.md) for presentations and more application patterns.
+See [references/applications.md](references/applications.md) when applying SUCCESs to a specific format—it has element-by-element tables, fill-in templates, and before/after examples for landing pages, demos, onboarding, presentations, email campaigns, internal comms, and documentation. See [references/case-studies.md](references/case-studies.md) for full worked teardowns (JFK's moonshot, the Subway diet, Don't Mess with Texas) when you want to see all six traits operating together in a famous message.
 
 ## Common Mistakes
 
@@ -238,28 +223,18 @@ See: [references/applications.md](references/applications.md) for presentations 
 
 ## Quick Diagnostic
 
-Audit any message:
+The single scoring instrument. Score each trait 1-10, fix the lowest, then re-score:
 
-| Question | If No | Action |
-|----------|-------|--------|
-| Can I state the core in one sentence? | Too complex | Find Commander's Intent |
-| Would this surprise someone? | Predictable = forgettable | Find the counterintuitive angle |
-| Can I picture it happening? | Too abstract | Add specific, sensory details |
-| Why should someone believe this? | No credibility | Add proof, examples, Sinatra Test |
-| Does it make me feel something? | Purely logical | Focus on one person, not statistics |
-| Is there a story? | List of facts | Wrap in character + problem + resolution |
+| Trait | Question | If weak | Fix |
+|-------|----------|---------|-----|
+| **Simple** | Can I state the core in one sentence? | Too complex | Find the Commander's Intent |
+| **Unexpected** | Would this surprise someone? | Predictable = forgettable | Find the counterintuitive angle |
+| **Concrete** | Can I picture it happening? | Too abstract | Add specific, sensory details |
+| **Credible** | Why should someone believe this? | No credibility | Add proof, examples, Sinatra Test |
+| **Emotional** | Does it make me feel something? | Purely logical | Focus on one person, not statistics |
+| **Stories** | Is there a story? | List of facts | Wrap in character + problem + resolution |
 
-## Reference Files
-
-- [simple.md](references/simple.md): Commander's Intent, core finding, simplification
-- [unexpected.md](references/unexpected.md): Surprise techniques, curiosity gaps
-- [concrete.md](references/concrete.md): Sensory language, specificity, demonstrations
-- [credible.md](references/credible.md): Authority types, Sinatra Test, human-scale statistics
-- [emotional.md](references/emotional.md): Individual focus, identity appeals, Maslow
-- [stories.md](references/stories.md): Three plots, story structure, collection methods
-- [curse-of-knowledge.md](references/curse-of-knowledge.md): Diagnosis and remedies
-- [applications.md](references/applications.md): Landing pages, demos, onboarding, presentations
-- [case-studies.md](references/case-studies.md): JFK moonshot, Subway diet, Don't Mess with Texas
+Sum the six scores and band per [Scoring](#scoring) above.
 
 ## Further Reading
 

--- a/microinteractions/SKILL.md
+++ b/microinteractions/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: microinteractions
-description: 'Design the small details -- triggers, rules, feedback, loops and modes -- that separate good products from great ones. Use when the user mentions "microinteraction", "button feedback", "loading state", "toggle design", "animation detail", "interaction polish", "state transitions", "input feedback", "the interface feels dead", "make the UI feel responsive", or "add polish to interactions". Also trigger when designing form-validation responses, progress indicators, confirmation dialogs, or any element where the user expects immediate feedback. Covers trigger design, state rules, feedback mechanisms, and progressive loops. For overall UI polish, see refactoring-ui. For affordance design, see design-everyday-things.'
+description: 'Design the small details -- triggers, rules, feedback, loops and modes -- that separate good products from great ones. Use when the user mentions "microinteraction", "button feedback", "loading state", "toggle design", "animation detail", "state transitions", "input feedback", "the interface feels dead", "make the UI feel responsive", or "add polish to interactions". Also trigger when designing form-validation responses, progress indicators, confirmation dialogs, or any element where the user expects immediate feedback. Covers trigger design, state rules, feedback mechanisms, and progressive loops. For overall UI polish, see refactoring-ui. For affordance design, see design-everyday-things.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Microinteractions Framework
@@ -17,17 +17,22 @@ Design the tiny, contained product moments users touch every day -- toggles, pas
 
 ## Scoring
 
-**Goal: 10/10.** Rate microinteractions 0-10 against the principles below: a 10/10 gives every interactive moment a deliberate trigger, clear rules, immediate feedback, and thoughtful loop/mode behavior. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score by counting how many of the 8 Quick Diagnostic rows the microinteraction passes (one point each), then map to a band:
+- **9-10** = passes all 8 rows: deliberate discoverable trigger with visible states, simple predictable rules, sub-100ms feedback scaled to event significance, evolves over time, mode-free or mode-visible, learnable without help.
+- **5-6** = 4-5 rows pass: it works but has a generic feel -- e.g. feedback exists but is uniform, or the trigger lacks distinct states.
+- **<=3** = 2 or fewer rows pass: missing feedback, invisible triggers, or hidden modes that break trust.
+
+Always state the current score, which diagnostic rows failed, and the specific fix for each.
 
 ## The Microinteraction Structure
 
-Six areas of focus for designing world-class microinteractions:
+Six areas of focus for designing world-class microinteractions. See [references/case-studies.md](references/case-studies.md) when you want a full four-part breakdown of a real pattern -- form submission, toggle/switch, pull-to-refresh, loading states, and notifications, each from first use through edge cases.
 
 ### 1. Triggers
 
 **Core concept:** The trigger initiates a microinteraction -- manual (tap, click, swipe, voice command) or system-initiated (time, location, incoming data, error state). It is the front door of every microinteraction.
 
-**Why it works:** Without a clear trigger, users cannot discover or initiate the interaction, and the product cannot respond to changing conditions. Well-designed triggers make functionality discoverable and set accurate expectations.
+**Why it works:** A trigger's prominence and labeling set the user's expectation before they act -- a button that reads "Delete" in red signals an irreversible, high-stakes outcome, so feedback that follows feels predictable rather than surprising.
 
 **Key insights:**
 - A trigger must communicate three things: that it exists, what it does, and what state it is in
@@ -75,7 +80,7 @@ See: [references/rules-and-state.md](references/rules-and-state.md) for state ma
 
 **Core concept:** Feedback communicates the rules to the user, answering "What is happening right now?" -- visually (color, animation, movement), aurally (clicks, chimes), or haptically (vibration). Show only what matters: minimal, meaningful, contextual.
 
-**Why it works:** Without feedback, users cannot tell if their action registered, the system is working, or the operation succeeded. Too little feedback creates anxiety; too much creates noise; the right feedback at the right time makes interactions feel responsive and trustworthy.
+**Why it works:** Without feedback, users cannot tell if their action registered or the system is working, so they retap, abandon, or distrust the result. Feedback is what converts an invisible system state into a perceived response.
 
 **Key insights:**
 - Feedback must be immediate -- under 100ms for direct manipulation
@@ -141,7 +146,7 @@ See: [references/loops-modes.md](references/loops-modes.md) for long loops, mode
 | **Loading state** | Branded waiting experience | Slack: rotating quotes during load |
 | **Completion** | Celebratory confirmation | Stripe payment: animated checkmark with confetti |
 
-**Ethical boundary:** Never obscure important information or delay the user to show off an animation -- function precedes delight.
+**Ethical boundary:** Never block input or the next step behind a non-skippable celebration animation -- let the user tap through the confetti to proceed.
 
 See: [references/signature-moments.md](references/signature-moments.md) for when to invest and making mundane interactions delightful.
 
@@ -166,7 +171,7 @@ See: [references/signature-moments.md](references/signature-moments.md) for when
 | **Single action** | One tap replaces multi-step flow | Double-tap to like instead of menu + select reaction |
 | **Anticipatory design** | Predict and pre-fill | Shipping form fills city and state from ZIP code |
 
-**Ethical boundary:** Do not auto-opt users into business-serving features or remove control over meaningful choices.
+**Ethical boundary:** A "smart default" must serve the user, not the business -- never pre-check marketing opt-ins, paid add-ons, or data-sharing as the default choice.
 
 ## Common Mistakes
 
@@ -195,15 +200,6 @@ Audit any microinteraction:
 | Does the interaction evolve over time? | Power users still see beginner hints | Add progressive reduction through long loops |
 | Is the interaction free of unnecessary modes? | Users perform the wrong action in the wrong mode | Remove modes or make the current mode highly visible |
 | Could a first-time user figure it out without help? | Interaction needs explanation | Simplify or add a one-time hint via long loop |
-
-## Reference Files
-
-- [trigger-design.md](references/trigger-design.md): Manual and system triggers, trigger affordances, trigger states, invisible trigger design, placement and visibility
-- [rules-and-state.md](references/rules-and-state.md): Defining rules, state management, constraints, error states, edge cases
-- [feedback-patterns.md](references/feedback-patterns.md): Visual, audio, and haptic feedback, timing, progressive disclosure, preventing overload
-- [loops-modes.md](references/loops-modes.md): Open and closed loops, long loops, modes, mode errors, progressive complexity
-- [signature-moments.md](references/signature-moments.md): Brand-defining microinteractions, examples, when to invest, making mundane interactions delightful
-- [case-studies.md](references/case-studies.md): Detailed design breakdowns of form submission, toggle/switch, pull-to-refresh, loading states, and notifications
 
 ## Further Reading
 

--- a/microinteractions/SKILL.md
+++ b/microinteractions/SKILL.md
@@ -4,7 +4,7 @@ description: 'Design the small details -- triggers, rules, feedback, loops and m
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # Microinteractions Framework
@@ -17,7 +17,7 @@ Design the tiny, contained product moments users touch every day -- toggles, pas
 
 ## Scoring
 
-**Goal: 10/10.** Score by counting how many of the 8 Quick Diagnostic rows the microinteraction passes (one point each), then map to a band:
+**Goal: 10/10.** Score by how many of the 8 Quick Diagnostic rows the microinteraction passes — `score = round(passed / 8 × 10)`, then read the band:
 - **9-10** = passes all 8 rows: deliberate discoverable trigger with visible states, simple predictable rules, sub-100ms feedback scaled to event significance, evolves over time, mode-free or mode-visible, learnable without help.
 - **5-6** = 4-5 rows pass: it works but has a generic feel -- e.g. feedback exists but is uniform, or the trigger lacks distinct states.
 - **<=3** = 2 or fewer rows pass: missing feedback, invisible triggers, or hidden modes that break trust.

--- a/mom-test/SKILL.md
+++ b/mom-test/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: mom-test
-description: 'Talk to customers without leading them using Mom Test rules: discuss their life not your idea, ask about specifics in the past, and talk less. Use when the user mentions "customer interviews", "validate my idea", "users say they want it but dont buy", "leading questions", "The Mom Test", "customer feedback bias", "interview script", "how do I interview customers", "am I asking leading questions", or "is my customer feedback reliable". Also trigger when preparing user-research questions, interpreting ambiguous feedback, or designing customer-discovery that avoids false positives. Covers commitment and advancement, avoiding compliments, and extracting signal from noise. For product-market fit, see jobs-to-be-done. For rapid prototype testing, see design-sprint.'
+description: 'Talk to customers without leading them using Mom Test rules: discuss their life not your idea, ask about specifics in the past, and talk less. Use when the user mentions "customer interviews", "validate my idea", "users say they want it but dont buy", "leading questions", "The Mom Test", "customer feedback bias", or "interview script". Also trigger when preparing user-research questions, interpreting ambiguous feedback, or designing customer-discovery that avoids false positives. Covers commitment and advancement, avoiding compliments, and extracting signal from noise. For product-market fit, see jobs-to-be-done. For rapid prototype testing, see design-sprint.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # The Mom Test Framework
@@ -17,7 +17,12 @@ Framework for customer conversations that won't lead you astray, based on a fund
 
 ## Scoring
 
-**Goal: 10/10.** Rate customer conversations 0-10 against the principles below: a 10/10 focuses entirely on the customer's life and past behavior, with no leading, no pitching, and clear commitment signals. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 7/7.** Score a conversation (or interview plan) by the seven-row Quick Diagnostic below: **1 point per row that passes.**
+- **6-7** = focused on their life and past behavior, concrete facts captured, a real commitment (time/reputation/money) secured, they talked 80%+, and beliefs got updated.
+- **4-5** = some past-behavior facts but leaking into hypotheticals, compliments accepted as signal, or ending without an ask.
+- **<=3** = a pitch in disguise: leading questions, opinions and fluff, a polite zombie lead, no learning.
+
+Always state the current score out of 7, name the failing diagnostic rows, and give the specific fix for each.
 
 ## Framework Sections
 
@@ -44,12 +49,10 @@ Framework for customer conversations that won't lead you astray, based on a fund
 
 **Copy patterns:**
 - "Tell me about the last time you..."
-- "How are you dealing with that currently?"
 - "What else have you tried?"
+- "Why does that bother you?"
 
-**Ethical boundary:** Never weaponize someone's honest answers against them -- using vulnerability data to manipulate sales crosses the line.
-
-See: [references/question-patterns.md](references/question-patterns.md) for good vs bad question examples, the three rules in depth, and formulation exercises.
+See: [references/question-patterns.md](references/question-patterns.md) when drafting an interview script -- a 5-tier question hierarchy, domain-specific question banks (SaaS/consumer/marketplace), and four formulation exercises.
 
 ### 2. Good vs Bad Questions
 
@@ -76,9 +79,7 @@ See: [references/question-patterns.md](references/question-patterns.md) for good
 **Copy patterns:**
 - "What's the hardest part about [doing this thing]?"
 - "How often does this come up?"
-- "Talk me through the last time this happened"
-
-**Ethical boundary:** Never use leading or loaded questions that anchor the respondent toward your desired answer -- your job is to learn, not to sell.
+- "Walk me through what happened the last time this came up"
 
 ### 3. Avoiding Compliments and Opinions
 
@@ -106,9 +107,7 @@ See: [references/question-patterns.md](references/question-patterns.md) for good
 - "When you say you'd 'definitely' use this, what would you stop using?"
 - "That's a great feature idea -- what problem would it solve for you specifically?"
 
-**Ethical boundary:** Deflecting compliments is about getting to truth, not pressuring someone into a sale.
-
-See: [references/avoiding-bad-data.md](references/avoiding-bad-data.md) for the three bad-data types and deflection scripts.
+See: [references/avoiding-bad-data.md](references/avoiding-bad-data.md) when a conversation feels good but yields no facts -- how to spot and deflect the three bad-data types (compliments, fluff, ideas) in real time.
 
 ### 4. Commitment and Advancement
 
@@ -136,9 +135,7 @@ See: [references/avoiding-bad-data.md](references/avoiding-bad-data.md) for the 
 - "Would you be willing to try a prototype next week?"
 - "If I built this, would you be willing to pilot it for 30 days?"
 
-**Ethical boundary:** Separate real interest from politeness -- never pressure people into commitments they'll regret.
-
-See: [references/commitment-advancement.md](references/commitment-advancement.md) for commitment currencies and pushing for advancement.
+See: [references/commitment-advancement.md](references/commitment-advancement.md) when a conversation ends without a commitment -- the currency ladder (time/reputation/money) and scripts for advancing instead of spinning wheels.
 
 ### 5. Finding Conversations
 
@@ -168,7 +165,7 @@ See: [references/commitment-advancement.md](references/commitment-advancement.md
 
 **Ethical boundary:** Never disguise a sales call as a learning conversation -- if you already have a product and are selling, be transparent.
 
-See: [references/finding-conversations.md](references/finding-conversations.md) for cold vs warm approaches and keeping it casual.
+See: [references/finding-conversations.md](references/finding-conversations.md) when you need to source interviews -- cold vs warm outreach templates, the five-part meeting ask (vision/framing/weakness/pedestal/ask), and how to keep it casual.
 
 ### 6. Processing and Learning
 
@@ -197,9 +194,7 @@ See: [references/finding-conversations.md](references/finding-conversations.md) 
 - "We've heard this from N of M people -- is that enough signal?"
 - "Time to stop talking and build -- conversations are repeating"
 
-**Ethical boundary:** Never selectively quote conversations to justify a predetermined conclusion -- honest processing means accepting uncomfortable truths.
-
-See: [references/processing-learning.md](references/processing-learning.md) for note-taking systems and knowing when to stop talking.
+See: [references/processing-learning.md](references/processing-learning.md) after a batch of interviews -- the notes-to-beliefs spreadsheet template, team-review cadence, and signals that it's time to stop talking and build.
 
 ## Common Mistakes
 
@@ -225,14 +220,7 @@ See: [references/processing-learning.md](references/processing-learning.md) for 
 | Did you update your beliefs based on the conversation? | You're collecting data but not learning | Review notes with the team; update problem/segment/solution beliefs |
 | Can you summarize the key facts (not opinions)? | Poor notes, or opinions confused with facts | Separate facts from interpretations immediately after |
 
-## Reference Files
-
-- [question-patterns.md](references/question-patterns.md): Good vs bad question examples, the three rules in depth, question formulation exercises
-- [commitment-advancement.md](references/commitment-advancement.md): Commitment currencies, advancing vs spinning wheels, how to push for commitment
-- [avoiding-bad-data.md](references/avoiding-bad-data.md): Compliments, fluff, ideas -- the three types of bad data and how to deflect them
-- [finding-conversations.md](references/finding-conversations.md): Where to find people, cold vs warm approaches, keeping conversations casual
-- [processing-learning.md](references/processing-learning.md): Note-taking, team sharing, updating beliefs, knowing when to stop talking
-- [case-studies.md](references/case-studies.md): Realistic scenarios showing Mom Test principles applied to SaaS, consumer, B2B, and marketplace contexts
+See: [references/case-studies.md](references/case-studies.md) when you want to see the rules applied end-to-end -- realistic SaaS, consumer, B2B, and marketplace interviews scored against this diagnostic.
 
 ## Further Reading
 

--- a/monetizing-innovation/SKILL.md
+++ b/monetizing-innovation/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: monetizing-innovation
-description: 'Design products and pricing around validated willingness to pay, from Ramanujam & Tacke''s "Monetizing Innovation". Use when the user mentions "pricing", "how much should we charge", "what should I charge", "willingness to pay", "pricing page", "pricing tiers", "packaging", "freemium vs free trial", "are we leaving money on the table", "nobody buys at this price", "price increase", or "good-better-best". Also trigger when designing or auditing pricing and packaging, validating willingness to pay before building, segmenting customers by value, or choosing between subscription, usage-based, and freemium models. Covers price-before-product, willingness-to-pay talks, the four failures (feature shock, minivation, hidden gem, undead), leader/filler/killer packaging, and behavioral pricing. For offers and guarantees, see hundred-million-offers. For what customers value, see jobs-to-be-done.'
+description: 'Design products and pricing around validated willingness to pay, from Ramanujam & Tacke''s "Monetizing Innovation". Use when the user mentions "pricing", "how much should we charge", "willingness to pay", "pricing page", "packaging", "freemium vs free trial", "are we leaving money on the table", "nobody buys at this price", "price increase", or "good-better-best". Also trigger when designing or auditing pricing and packaging, validating willingness to pay before building, segmenting customers by value, or choosing between subscription, usage-based, and freemium models. Covers price-before-product, willingness-to-pay talks, the four failures (feature shock, minivation, hidden gem, undead), leader/filler/killer packaging, and behavioral pricing. For offers and guarantees, see hundred-million-offers. For what customers value, see jobs-to-be-done.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Monetizing Innovation
@@ -51,7 +51,7 @@ A framework for designing the product around the price, distilled from Simon-Kuc
 
 **Ethical boundary:** WTP research exists to match price to delivered value — not to find each customer's maximum pain and extract it.
 
-See: [references/wtp-conversations.md](references/wtp-conversations.md)
+See [references/wtp-conversations.md](references/wtp-conversations.md) before you run interviews: the exact question scripts (direct, purchase-probability, acceptable/expensive/prohibitive), the simplified-conjoint procedure, sample sizes for B2B vs B2C, how to read the answers, and how to turn a WTP range into specs.
 
 ### 2. The Four Monetization Failures
 
@@ -77,7 +77,7 @@ See: [references/wtp-conversations.md](references/wtp-conversations.md)
 
 **Ethical boundary:** "Kill the undead" applies to products, never to evidence — massaging research to keep a favorite alive creates the next undead.
 
-See: [references/four-failures.md](references/four-failures.md)
+See [references/four-failures.md](references/four-failures.md) when a product is underperforming and you need to classify it: symptom checklists, root causes, the matching countermeasure, and a worked example for each of feature shock, minivation, hidden gems, and undead, plus a classification decision tree.
 
 ### 3. Segment by Willingness to Pay
 
@@ -103,13 +103,13 @@ See: [references/four-failures.md](references/four-failures.md)
 
 **Ethical boundary:** Differentiate prices by value delivered and offer differences — never by exploiting captivity or protected characteristics.
 
-See: [references/case-studies.md](references/case-studies.md)
+See [references/wtp-conversations.md](references/wtp-conversations.md) (the "Build the WTP curve, not the average" section) when your interview data is in hand: reading cliffs and plateaus to find segments, why the mean of a bimodal market describes a customer who does not exist, and the worked WTP-curve example.
 
 ### 4. Packaging and Bundling
 
 **Core concept:** Classify every feature as a leader (drives the purchase decision), a filler (adds modest value), or a killer (actively reduces WTP if customers are forced to pay for it). Build good-better-best tiers around leaders, use fillers to round out and differentiate, and pull killers out into add-ons — or out of the product.
 
-**Why it works:** Packaging decides whether each segment can find the version built for it. Leaders give each tier a reason to exist; a premium tier anchors the middle as reasonable; killers left in a bundle give buyers a reason to say no to the whole thing. The same features, packaged differently, can double or halve revenue.
+**Why it works:** Leaders give each tier a reason to exist; a premium tier anchors the middle as reasonable; a single killer left in a bundle gives buyers a reason to reject the whole thing, not just that feature. The same features, packaged differently, can double or halve revenue.
 
 **Key insights:**
 - A killer is not a bad feature — it is value one segment refuses to fund; on-prem deployment is a killer for SMBs and a leader for banks
@@ -129,7 +129,7 @@ See: [references/case-studies.md](references/case-studies.md)
 
 **Ethical boundary:** Fence tiers on value added, never on essentials held hostage — security, privacy, and data export belong in every tier.
 
-See: [references/packaging-tiers.md](references/packaging-tiers.md)
+See [references/packaging-tiers.md](references/packaging-tiers.md) when you are slotting features into tiers: the leader/filler/killer scoring procedure, good-better-best design rules, a feature-allocation matrix, tier naming, upgrade paths, the bundling checklist, and pricing-page implications.
 
 ### 5. Choosing the Monetization Model
 
@@ -155,7 +155,7 @@ See: [references/packaging-tiers.md](references/packaging-tiers.md)
 
 **Ethical boundary:** Pick metrics customers can predict and audit — a surprise bill monetizes confusion, not value.
 
-See: [references/monetization-models.md](references/monetization-models.md)
+See [references/monetization-models.md](references/monetization-models.md) when you are choosing how to charge: when each model wins (subscription, usage, hybrid, freemium, dynamic, outcome-based), the failure mode of each, how to choose the price metric, and how to migrate between models without churning your base.
 
 ### 6. Behavioral Pricing and Price Communication
 
@@ -207,13 +207,9 @@ See: [references/monetization-models.md](references/monetization-models.md)
 | Is there a living business case linking WTP, price, volume, and cost? | Targets are fiction | Build it before launch; update it on every change |
 | Are post-launch reaction triggers agreed in advance? | Week-one fear will set pricing | Define day-30/60/90 metrics, thresholds, and responses now |
 
-## Reference Files
+## Worked Examples
 
-- [references/wtp-conversations.md](references/wtp-conversations.md) — Question scripts (direct, purchase-probability, acceptable/expensive/prohibitive), simplified conjoint, interpreting answers, sample sizes, B2B vs B2C, turning WTP into specs
-- [references/four-failures.md](references/four-failures.md) — Symptom checklists, root causes, countermeasures, and worked examples for feature shock, minivation, hidden gems, and undead products, plus a classification decision tree
-- [references/packaging-tiers.md](references/packaging-tiers.md) — Leader/filler/killer procedure, good-better-best design rules, tier naming, feature-allocation matrix, upgrade paths, bundling checklist, pricing-page implications
-- [references/monetization-models.md](references/monetization-models.md) — Subscription, usage, hybrid, freemium, dynamic, and outcome-based models: when each wins, failure modes, choosing the price metric, migrating between models
-- [references/case-studies.md](references/case-studies.md) — Three scenarios: flat-to-tiered repricing after WTP interviews, catching feature shock pre-launch, fixing freemium conversion with a leader paywall
+See [references/case-studies.md](references/case-studies.md) to watch the whole framework run end-to-end on three companies: flat-to-tiered repricing after WTP interviews surfaced three segments, catching feature shock pre-launch when the WTP curve stayed flat as scope grew, and fixing a 1.1% freemium conversion by moving the leader behind the paywall.
 
 ## Further Reading
 

--- a/negotiation/SKILL.md
+++ b/negotiation/SKILL.md
@@ -4,7 +4,7 @@ description: 'Prepare and execute negotiations using tactical empathy, calibrate
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Negotiation
@@ -17,7 +17,7 @@ Tactical empathy-based negotiation framework from FBI hostage negotiator Chris V
 
 ## Scoring
 
-**Goal: 10/10.** Rate negotiation preparation or execution 0-10 against the principles below: a 10/10 means full tactical empathy, calibrated questions prepared, accusation audit delivered, emotions labeled, "That's right" achieved, and Black Swans actively hunted. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score 1 point per satisfied Quick Diagnostic row (6 rows), plus up to 4 points for execution quality: emotions labeled out loud (+1), "That's right" earned not "You're right" (+1), no "Why?" / no splitting the difference / no chasing "yes" (+1), at least one Black Swan surfaced (+1). Bands: **9-10** = audit delivered, calibrated questions and BATNA prepared, "That's right" achieved, Black Swans hunted; **5-6** = some prep but arguing the position or chasing "yes"; **<=3** = no audit, no BATNA, splitting the difference. Always state the current score and the specific gaps to reach 10/10.
 
 ## Framework
 
@@ -47,9 +47,7 @@ Tactical empathy-based negotiation framework from FBI hostage negotiator Chris V
 - "It seems like this is creating pressure for your team..."
 - "Before we talk about next steps, I want to make sure I understand where you're coming from..."
 
-**Ethical boundary:** Use empathy to genuinely understand, not to manipulate emotions.
-
-See: [references/techniques.md](references/techniques.md) for complete breakdowns, psychological triggers, and worked examples for every technique in this skill.
+See [references/techniques.md](references/techniques.md) for the full 21-technique reference -- each section below points to the part you need at the moment you need it. Open it now for The Power of Apology and Pause, which has no section here.
 
 ### 2. Mirroring
 
@@ -76,8 +74,6 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 - "You mentioned [their exact words]..."
 - "When you say [mirror], what does that look like?"
 
-**Ethical boundary:** Mirror to understand, not to pry out information people want to keep private.
-
 ### 3. Labeling
 
 **Core concept:** Identify and verbalize the counterpart's emotions or perspective using neutral phrases: "It seems like...", "It sounds like...", "It looks like..."
@@ -102,8 +98,6 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 - "It seems like..."
 - "It sounds like you're feeling..."
 - "If I'm reading this right, it feels like..."
-
-**Ethical boundary:** Label emotions to show understanding, not to weaponize feelings.
 
 ### 4. Calibrated Questions
 
@@ -131,7 +125,7 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 - "What's the biggest challenge you're facing?"
 - "What would it take to make this happen?"
 
-**Ethical boundary:** Create genuine collaboration, not traps into commitments people don't want to make.
+For No-oriented questions ("Would it be unreasonable to...?") and tactical mislabeling to draw out a corrective "No", see techniques.md section 8 when a counterpart is guarded or stalling.
 
 ### 5. Accusation Audit
 
@@ -158,8 +152,6 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 - "I know this might seem like..."
 - "You might be wondering why you should even listen to..."
 
-**Ethical boundary:** Build trust through transparency -- never use audits to preemptively shut down legitimate concerns.
-
 ### 6. "That's Right"
 
 **Core concept:** Summarize the counterpart's position -- facts, emotions, and concerns -- so accurately that they respond with "That's right." This is the breakthrough moment in any negotiation.
@@ -185,7 +177,7 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 - "If I'm hearing you correctly..."
 - "It sounds like [complete summary of their position including emotions]..."
 
-**Ethical boundary:** Earn "That's right" through genuine understanding, not manipulative reframing of their position.
+For the three types of Yes (counterfeit, confirmation, commitment) and the Rule of Three confirmation sequence, see techniques.md sections 10-11 when closing or locking in a commitment.
 
 ### 7. Ackerman Bargaining
 
@@ -198,7 +190,6 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 - Use precise, non-round numbers on the final offer ($10,230 not $10,000)
 - Attach a non-monetary bonus to the final offer ("...and I'll include X")
 - Never make a concession without getting something in return
-- Against an extreme anchor, don't counter -- ask "How did you arrive at that figure?"
 
 **Product applications:**
 
@@ -213,7 +204,7 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 - "We've stretched as far as we can -- $[precise number], and we'll include [non-monetary bonus]"
 - "I've gone back to my team and the absolute best we can do is $[precise number]"
 
-**Ethical boundary:** Use the Ackerman method for fair negotiations, not to lowball or exploit people who lack negotiation skills.
+For setting the opening anchor, soft range-anchoring, and framing loss aversion, see techniques.md section 14 before you name the first number.
 
 ### 8. Black Swans
 
@@ -240,7 +231,7 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 - "Help me understand -- what's really driving this?"
 - "What would change everything about this situation?"
 
-**Ethical boundary:** Hunt Black Swans to create better outcomes for both sides, not to exploit private or sensitive information.
+For applying the three leverage types, reading pronoun shifts that reveal who really decides, and using dynamic silence to draw out hidden information, see techniques.md sections 16, 20, and 21 when a negotiation stalls or you suspect a hidden decision-maker.
 
 ## Handling Common Situations
 
@@ -266,6 +257,8 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 - **After key statements**: Pause 4+ seconds (tactical silence)
 - **Watch their nonverbals**: 7% words, 38% tone, 55% body language
 
+See techniques.md sections 4 and 19 when you need the full Late-Night DJ Voice mechanics and the cues to read in their body language.
+
 ## Common Mistakes
 
 | Mistake | Why It Fails | Fix |
@@ -288,10 +281,6 @@ See: [references/techniques.md](references/techniques.md) for complete breakdown
 | Am I aiming for "That's right"? | You'll chase counterfeit "yes" | Summarize their position until they affirm genuinely |
 | Have I considered their negotiation style? | One-size-fits-all will misfire | Assess if they're Analyst, Accommodator, or Assertive |
 | Am I hunting for Black Swans? | You'll miss game-changing information | Stay curious; watch for anomalies; ask about the unexpected |
-
-## Reference Files
-
-- [techniques.md](references/techniques.md): Complete technique breakdowns -- mirroring, labeling, tactical empathy, voice control, accusation audits, calibrated questions, no-oriented questions, "That's right", the Ackerman method, Black Swans, counterpart styles, body language, and pronoun analysis -- with examples and psychological triggers
 
 ## Further Reading
 

--- a/obviously-awesome/SKILL.md
+++ b/obviously-awesome/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: obviously-awesome
-description: 'Define product positioning by mapping competitive alternatives, unique attributes, and best-fit customers to the right market category. Use when the user mentions "positioning", "competitive alternatives", "how to position", "market category", "why customers dont get it", "positioning canvas", "repositioning", "category creation", "prospects dont understand what we do", "what category are we in", or "how do we explain what we do". Also trigger when launching a new product, entering a crowded market, or diagnosing why prospects dont grasp the product''s value. Covers the positioning canvas and team workshops. For customer jobs analysis, see jobs-to-be-done. For go-to-market, see crossing-the-chasm.'
+description: 'Define product positioning by mapping competitive alternatives, unique attributes, and best-fit customers to the right market category. Use when the user mentions "positioning", "competitive alternatives", "how to position", "market category", "positioning canvas", "repositioning", "category creation", "what category are we in", or "why prospects dont get what we do". Also trigger when launching a new product, entering a crowded market, or diagnosing why prospects dont grasp the product''s value. Covers the positioning canvas and team workshops. For customer jobs analysis, see jobs-to-be-done. For go-to-market, see crossing-the-chasm.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Product Positioning Framework
@@ -29,20 +29,24 @@ Positioning defines the context within which customers evaluate your product -- 
 | 7-8 | Strong: all five components defined, team aligned, customers generally understand the value |
 | 9-10 | Exceptional: every component reinforces the others; customers immediately get what it is, why it's different, and why they should care |
 
-## The 10 Positioning Components
+## The Positioning Canvas
 
-| Component | Description | Example |
-|-----------|-------------|---------|
-| Competitive Alternatives | What customers would use if you didn't exist | Spreadsheets, consultants, doing nothing |
-| Unique Attributes | Capabilities only your product has | Real-time collaboration on financial models |
-| Value Themes | Benefits customers get from unique attributes | Save 10 hours/week on financial reporting |
-| Best-Fit Customers | Who cares most about your value | Mid-market CFOs managing 3+ business units |
-| Market Category | The market you describe yourself as part of | FP&A software |
-| Relevant Trends | Dynamics that make positioning resonate now | Remote finance teams need real-time collaboration |
-| Positioning Statement | Internal one-line summary for team alignment | "For mid-market CFOs, the FP&A platform built for real-time collaboration" |
-| Sales Narrative | Positioning as a compelling sales story | Problem -> old way -> new way -> your solution -> proof |
-| Messaging | External language derived from positioning | "Financial planning that keeps up with your business" |
-| Content Strategy | What content positioning tells you to create | Thought leadership on collaborative finance |
+The 10 outputs of positioning, captured in one place. Steps 1-5 build the top five; the rest are derived from them. Every team member should fill this out and arrive at the same answers -- divergence signals misalignment.
+
+| Component | Fill-in Question | Example Answer |
+|-----------|------------------|----------------|
+| Competitive Alternatives | What would customers use if we didn't exist? | Spreadsheets, consultants, doing nothing |
+| Unique Attributes | What do we have that alternatives don't? | Real-time collaboration on financial models |
+| Value Themes | What value do those attributes enable? | Save 10 hours/week on financial reporting |
+| Best-Fit Customers | Who cares most about that value? | Mid-market CFOs managing 3+ business units |
+| Market Category | What market frame makes our value obvious? | FP&A software |
+| Relevant Trends | What market dynamics create urgency now? | Remote finance teams need real-time collaboration |
+| Positioning Statement | For [target], we are the [category] that [key value] | "For mid-market CFOs, the FP&A platform built for real-time collaboration" |
+| Key Proof Points | What evidence shows our claims are true? | Case studies, usage data, third-party benchmarks |
+| Sales Narrative | How do we tell this story in a sales conversation? | Problem -> old way -> new way -> our solution -> proof |
+| Messaging | What external headline derives from positioning? | "Financial planning that keeps up with your business" |
+
+See [references/positioning-canvas.md](references/positioning-canvas.md) when filling out the canvas for a real product -- it has the blank template plus three fully worked examples (B2B SaaS, consumer app, professional services).
 
 ## The 5-Step Positioning Process
 
@@ -53,7 +57,7 @@ Positioning defines the context within which customers evaluate your product -- 
 **Why it works:** Customers always evaluate products relative to alternatives, so "differentiated" only has meaning against the real alternatives in your customer's mind.
 
 **Key insights:**
-- Ask existing happy customers, not prospects -- they can tell you what they actually switched from
+- Interview 15-20 existing happy customers, not prospects -- they can tell you what they actually switched from
 - The most common alternative is often not a product -- it's a spreadsheet, a manual process, or the status quo
 - "Do nothing" is your biggest competitor in many markets
 - Group similar alternatives ("general-purpose spreadsheets" rather than Excel, Sheets, Numbers)
@@ -74,7 +78,7 @@ Positioning defines the context within which customers evaluate your product -- 
 
 **Ethical boundary:** Base alternatives on actual customer research, never assumptions or wishful thinking.
 
-See: [Competitive Alternatives Analysis](references/competitive-alternatives.md) for interview scripts, clustering, and "do nothing" analysis.
+See [references/competitive-alternatives.md](references/competitive-alternatives.md) when preparing or running the customer interviews -- it has the full question script, the five alternative types, clustering, and "do nothing" analysis.
 
 ### Step 2: Identify Your Unique Attributes
 
@@ -104,7 +108,7 @@ See: [Competitive Alternatives Analysis](references/competitive-alternatives.md)
 
 **Ethical boundary:** Never claim attributes that aren't genuinely unique -- if a competitor has it, it's table stakes.
 
-See: [Unique Attributes Discovery](references/unique-attributes.md) for the workshop process and verification techniques.
+See [references/unique-attributes.md](references/unique-attributes.md) when running the attribute-discovery workshop -- it has the elicitation process, the "only we" verification, and clustering into themes.
 
 ### Step 3: Map Attributes to Customer Value
 
@@ -132,9 +136,7 @@ See: [Unique Attributes Discovery](references/unique-attributes.md) for the work
 - "Our customers [measurable outcome] because [unique capability]"
 - "[Number]% of customers report [value] within [timeframe]"
 
-**Ethical boundary:** Back every value claim with evidence from real customer outcomes -- never exaggerate.
-
-See: [Value Mapping Framework](references/value-mapping.md) for the "So what?" chain and proof point creation.
+See [references/value-mapping.md](references/value-mapping.md) when running the "So what?" chain on attributes -- it has the full Feature->Advantage->Value walkthrough and proof-point creation.
 
 ### Step 4: Define Your Best-Fit Target Customers
 
@@ -164,7 +166,7 @@ See: [Value Mapping Framework](references/value-mapping.md) for the "So what?" c
 
 **Ethical boundary:** Best-fit definition is about focus, not exclusion -- never denigrate other segments.
 
-See: [Target Customer Analysis](references/target-customers.md) for actionable segmentation criteria and TAM differentiation.
+See [references/target-customers.md](references/target-customers.md) when defining best-fit criteria -- it has the actionable-segmentation tests, negative criteria, personas, and how best-fit differs from TAM.
 
 ### Step 5: Choose Your Market Category
 
@@ -194,7 +196,7 @@ See: [Target Customer Analysis](references/target-customers.md) for actionable s
 
 **Ethical boundary:** Don't create a new category purely to avoid competition -- only when your product genuinely can't be understood within existing frameworks.
 
-See: [Market Category Strategy](references/market-category.md) for the decision framework and education-tax analysis.
+See [references/market-category.md](references/market-category.md) when choosing between head-to-head, subcategory, and new category -- it has the decision framework and the education-tax analysis.
 
 ## Market Reference Points
 
@@ -202,30 +204,11 @@ Trends act as tailwinds: a real, widely acknowledged trend that connects directl
 
 **Warning signs of trend abuse:** your positioning only makes sense in light of the trend; the trend connects to no unique attribute; the trend is aspirational rather than actually happening.
 
-## The Positioning Canvas
-
-Capture positioning decisions in one place -- every team member should be able to fill this out consistently.
-
-| Component | Your Answer |
-|-----------|-------------|
-| **Competitive Alternatives** | What would customers use if we didn't exist? |
-| **Unique Attributes** | What do we have that alternatives don't? |
-| **Value Themes** | What value do those attributes enable? |
-| **Best-Fit Customers** | Who cares the most about that value? |
-| **Market Category** | What market frame makes our value obvious? |
-| **Relevant Trends** | What market dynamics create urgency? |
-| **Positioning Statement** | For [target], we are the [category] that [key value] |
-| **Key Proof Points** | Evidence that our claims are true |
-| **Primary Message** | External headline derived from positioning |
-| **Sales Narrative** | How we tell this story in a sales conversation |
-
-See: [Positioning Canvas with Worked Examples](references/positioning-canvas.md) for the blank template plus three fully worked examples.
-
 ## Team Positioning Exercise
 
 Positioning requires cross-functional alignment: include founders (vision), product (unique attributes), sales (objections and alternatives), marketing (category and messaging), and customer success (best-fit evidence). Run it in three parts: pre-work gathering customer research and win/loss data (1-2 weeks before), a 2-3 hour workshop walking all five steps to consensus, and post-work documenting the canvas and aligning customer-facing materials. The most important output is alignment -- everyone describing the product the same way.
 
-See: [Team Exercise Facilitator Guide](references/team-exercise.md) for a minute-by-minute agenda and remote adaptations.
+See [references/team-exercise.md](references/team-exercise.md) when facilitating the workshop -- it has the minute-by-minute agenda, pre-work checklist, and remote adaptations.
 
 ## Common Mistakes
 
@@ -237,7 +220,7 @@ See: [Team Exercise Facilitator Guide](references/team-exercise.md) for a minute
 | Copying competitor positioning | Invites direct comparison on their terms | Build positioning from attributes only you can own |
 | Changing positioning too frequently | Confuses customers, sales, and market | Commit for 6-12 months; adjust messaging more often |
 | Creating a new category prematurely | Pays the "education tax" without resources to educate | Start in an existing category or subcategory; create new only with traction and resources |
-| Ignoring competitive alternatives | Differentiation exists in a vacuum | Interview 15-20 happy customers about what they used before |
+| Ignoring competitive alternatives | Differentiation exists in a vacuum | Run the Step 1 happy-customer interviews about what they used before |
 
 ## Quick Diagnostic
 
@@ -246,20 +229,11 @@ See: [Team Exercise Facilitator Guide](references/team-exercise.md) for a minute
 | Can every team member describe the product the same way? | Positioning isn't aligned | Run a team positioning exercise |
 | Do prospects understand what you do in under 30 seconds? | Category is wrong or unclear | Re-evaluate your market category choice |
 | Can you name 3 things you do that no competitor does? | Weak unique attributes | Deep-dive attribute discovery with customer input |
-| Do you know what customers would use if you didn't exist? | Unknown competitive alternatives | Interview 15-20 happy customers about alternatives |
+| Do you know what customers would use if you didn't exist? | Unknown competitive alternatives | Run the Step 1 happy-customer interviews on alternatives |
 | Can you articulate why best-fit customers choose you? | Value themes are unclear | Run the "So what?" mapping exercise |
 | Is your best-fit definition specific enough to target proactively? | Target is too broad | Analyze best customers for common actionable characteristics |
 
-## Reference Files
-
-- [Competitive Alternatives Analysis](references/competitive-alternatives.md) — Customer interview scripts, clustering techniques, and the "do nothing" analysis
-- [Unique Attributes Discovery](references/unique-attributes.md) — Workshop process for identifying genuinely unique attributes, verification, and clustering
-- [Value Mapping Framework](references/value-mapping.md) — The "So what?" chain, value theme identification, proof points, and value hierarchy
-- [Target Customer Analysis](references/target-customers.md) — Best-fit analysis, actionable segmentation criteria, personas, and TAM differentiation
-- [Market Category Strategy](references/market-category.md) — All three category strategies, decision framework, education tax, when to change categories
-- [Positioning Canvas with Worked Examples](references/positioning-canvas.md) — Blank template plus three fully worked examples (B2B SaaS, consumer app, professional services)
-- [Team Exercise Facilitator Guide](references/team-exercise.md) — Minute-by-minute agenda, preparation requirements, and remote adaptations
-- [Positioning Case Studies](references/case-studies.md) — Real-world examples including repositioning wins, niche discovery, and category creation
+See [references/case-studies.md](references/case-studies.md) when you want a worked precedent to model a real engagement on -- it walks through repositioning wins, niche discovery, and category creation end to end.
 
 ## Further Reading
 

--- a/one-page-marketing/SKILL.md
+++ b/one-page-marketing/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: one-page-marketing
-description: 'Build a complete marketing plan covering the full customer journey from stranger to raving fan. Use when the user mentions "marketing plan", "target market", "USP", "lead nurture", "customer lifetime value", "marketing strategy", "PVP Index", "how do I market my business", "get more customers", "where do I find customers", or "I dont know where to start with marketing". Also trigger when building a marketing plan from scratch, choosing acquisition channels, or designing end-to-end customer-lifecycle campaigns. Covers the PVP Index, channel selection, and advocacy systems. For brand messaging, see storybrand-messaging. For conversion optimization, see cro-methodology.'
+description: 'Build a complete marketing plan covering the full customer journey from stranger to raving fan. Use when the user mentions "marketing plan", "marketing strategy", "target market", "USP", "lead nurture", "customer lifetime value", "PVP Index", or "I dont know where to start with marketing". Also trigger when building a marketing plan from scratch, choosing acquisition channels, or designing end-to-end customer-lifecycle campaigns. Covers the PVP Index, channel selection, and advocacy systems. For brand messaging, see storybrand-messaging. For conversion optimization, see cro-methodology.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # The 1-Page Marketing Plan Framework
@@ -19,14 +19,14 @@ Most businesses treat marketing as disconnected tactics: an ad here, a social po
 
 ## Scoring
 
-**Goal: 10/10.** Rate the marketing plan 0-10 by how completely and specifically all nine squares are filled in: a 10 means named target segments, a written USP, channels with budgets, a designed lead magnet, a mapped nurture sequence, a defined sales process, a documented experience, an ascension model with pricing tiers, and a referral system with scripts and tracking. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score by counting how many of the nine squares are filled in *specifically and measurably* -- a square counts only when it would pass its row in the Quick Diagnostic (e.g. square 1 counts only if you can describe the ideal customer in one specific paragraph; square 2 only if you can complete "We are the only ___ that ___"). Map the count to the band below. Always state the current score and the specific improvements needed to reach 10/10.
 
-| Score | Meaning |
-|-------|---------|
-| 0-3 | Fragmented tactics, no cohesive plan, significant gaps |
-| 4-6 | Some squares filled but vague; key phases missing (usually AFTER) |
-| 7-8 | All squares addressed with reasonable specificity; some lack detail |
-| 9-10 | Every square specific, measurable, and ready for execution |
+| Score | Squares passing the diagnostic | Meaning |
+|-------|-------------------------------|---------|
+| 0-3 | 0-2 | Fragmented tactics, no cohesive plan, significant gaps |
+| 4-6 | 3-5 | Some squares filled but vague; key phases missing (usually AFTER) |
+| 7-8 | 6-7 | All squares addressed with reasonable specificity; some lack detail |
+| 9-10 | 8-9 | Every square specific, measurable, and ready for execution |
 
 ## The 9-Square Grid
 
@@ -35,6 +35,8 @@ Most businesses treat marketing as disconnected tactics: an ad here, a social po
 | **BEFORE** | Prospect | 1. Target Market · 2. Message · 3. Media |
 | **DURING** | Lead | 4. Capture Leads · 5. Nurture · 6. Convert |
 | **AFTER** | Customer | 7. Experience · 8. Lifetime Value · 9. Referrals |
+
+See [references/one-page-plan-template.md](references/one-page-plan-template.md) when filling the grid -- it has the blank 9-square template with per-square prompts plus two fully worked examples.
 
 ## BEFORE Phase (Prospect to Lead)
 
@@ -63,15 +65,11 @@ Most businesses treat marketing as disconnected tactics: an ad here, a social po
 - "The only [product/service] designed specifically for [target market]"
 - "Unlike generic solutions, this was built from the ground up for [niche]"
 
-**Ethical boundary:** Select niches you can genuinely serve well -- never target vulnerable populations for exploitation.
-
-See: [references/target-market.md](references/target-market.md) for PVP scoring and the avatar worksheet.
+See [references/target-market.md](references/target-market.md) when selecting the niche -- it has the anchored PVP scoring rubric and the fillable avatar worksheet.
 
 ### 2. Craft Your Message
 
 **Core concept:** Your message must answer one question: "Why should I buy from you rather than your nearest competitor?" That answer is your Unique Selling Proposition (USP) -- without it you are a commodity competing on price.
-
-**Why it works:** A clear USP gives prospects a reason to choose you, gives marketing a consistent theme, and eliminates price competition -- transforming you from "one of many" to "the only one."
 
 **Key insights:**
 - A USP is not a slogan -- it is a defensible, provable market position
@@ -92,15 +90,11 @@ See: [references/target-market.md](references/target-market.md) for PVP scoring 
 - "The only [category] that [unique differentiator]"
 - "We guarantee [specific result] or [risk reversal]"
 
-**Ethical boundary:** Your USP must be truthful and deliverable -- never claim results you cannot substantiate or guarantees you won't honor.
-
-See: [references/craft-message.md](references/craft-message.md) for the USP creation process and elevator pitch formula.
+See [references/craft-message.md](references/craft-message.md) when drafting the USP -- it has the five USP strategies, the creation process, and the commodity-trap escapes.
 
 ### 3. Advertising Media
 
 **Core concept:** Apply direct response principles to every advertising dollar: trackable, measurable, and designed to provoke a specific action -- never vague "brand awareness." Choose channels where your target market actually spends time.
-
-**Why it works:** Direct response eliminates waste -- you ask for a specific action now and measure whether it happened, turning marketing from a cost center into a profit center.
 
 **Key insights:**
 - Pick channels by where the target market actually is, not what is trendy
@@ -121,9 +115,7 @@ See: [references/craft-message.md](references/craft-message.md) for the USP crea
 - "Attention [target market]: [headline about their pain/desire]"
 - "Call [tracked number] / Visit [tracked URL] to claim your [specific offer]"
 
-**Ethical boundary:** Keep all advertising truthful and compliant -- no deceptive claims or bait-and-switch.
-
-See: [references/advertising-media.md](references/advertising-media.md) for channel selection, CAC tracking, and attribution.
+See [references/advertising-media.md](references/advertising-media.md) when choosing channels -- it has the selection matrix, CAC-vs-LTV tracking, and attribution.
 
 ## DURING Phase (Lead to Customer)
 
@@ -153,9 +145,9 @@ See: [references/advertising-media.md](references/advertising-media.md) for chan
 - "Take the free [quiz/assessment] and discover your [score/type/result]"
 - "Get instant access to [resource] — no credit card required"
 
-**Ethical boundary:** Always deliver on the lead magnet's promise -- never use deceptive opt-ins or sell contact data without explicit consent.
+**Ethical boundary:** Collect only data you will use, and never sell or share contact data without explicit opt-in consent.
 
-See: [references/capture-leads.md](references/capture-leads.md) for lead magnet types, opt-in page design, and lead scoring.
+See [references/capture-leads.md](references/capture-leads.md) when designing the lead magnet and opt-in -- it has lead-magnet types, opt-in page design, and lead scoring.
 
 ### 5. Nurture Leads
 
@@ -183,9 +175,9 @@ See: [references/capture-leads.md](references/capture-leads.md) for lead magnet 
 - "How [client name] went from [before state] to [after state] in [time period]"
 - "I noticed you downloaded [lead magnet]. Here is the next step..."
 
-**Ethical boundary:** Provide one-click unsubscribe, honest frequency, and anti-spam compliance -- always respect communication preferences.
+**Ethical boundary:** Put one-click unsubscribe in every send and honor it immediately (CAN-SPAM / GDPR).
 
-See: [references/nurture-leads.md](references/nurture-leads.md) for sequence templates, cadence, and segmentation.
+See [references/nurture-leads.md](references/nurture-leads.md) when building the welcome sequence -- it has sequence templates, cadence, and behavioral segmentation.
 
 ### 6. Sales Conversion
 
@@ -213,9 +205,9 @@ See: [references/nurture-leads.md](references/nurture-leads.md) for sequence tem
 - "Join [number] [target market] who have already [achieved result]"
 - "Your investment is protected by our [guarantee name]"
 
-**Ethical boundary:** No high-pressure tactics, artificial scarcity, or manipulative closes -- the sale should follow naturally from demonstrated value and genuine fit.
+**Ethical boundary:** Use only real deadlines and genuine stock limits -- fabricated countdowns and fake scarcity destroy trust on the second purchase.
 
-See: [references/sales-conversion.md](references/sales-conversion.md) for pricing psychology, risk reversal, and objection handling.
+See [references/sales-conversion.md](references/sales-conversion.md) when handling price and objections -- it has pricing psychology, risk-reversal structures, and an objection map.
 
 ## AFTER Phase (Customer to Raving Fan)
 
@@ -245,9 +237,9 @@ See: [references/sales-conversion.md](references/sales-conversion.md) for pricin
 - "We just completed [milestone]. Here is what we found and what is next."
 - "You have been a customer for [X months]. We wanted to say thank you with [surprise]."
 
-**Ethical boundary:** Experience systems must genuinely serve the customer, not trap them -- make leaving easy; that confidence is what makes them stay.
+**Ethical boundary:** Make cancelling as easy as signing up -- no retention mazes or hidden offboarding; that confidence is what makes customers stay.
 
-See: [references/customer-experience.md](references/customer-experience.md) for moments of truth, NPS, and community building.
+See [references/customer-experience.md](references/customer-experience.md) when designing the post-sale experience -- it has moments of truth, NPS, and community building.
 
 ### 8. Increase Lifetime Value
 
@@ -275,9 +267,7 @@ See: [references/customer-experience.md](references/customer-experience.md) for 
 - "Upgrade to [tier] and unlock [specific benefit they care about]"
 - "We noticed you haven't [used product/visited] in a while. Here is a special reason to come back."
 
-**Ethical boundary:** Upsell only what genuinely benefits the customer -- the ascension model should reflect increasing value, not just increasing price.
-
-See: [references/lifetime-value.md](references/lifetime-value.md) for LTV formulas, ascension design, and reactivation.
+See [references/lifetime-value.md](references/lifetime-value.md) when building the ascension model -- it has LTV formulas, tier design, and reactivation campaigns.
 
 ### 9. Orchestrate Referrals
 
@@ -305,25 +295,21 @@ See: [references/lifetime-value.md](references/lifetime-value.md) for LTV formul
 - "You mentioned you are happy with [result]. Would you be open to sharing that experience with [specific person]?"
 - "We have a partnership with [trusted brand]. Their customers get [special offer]."
 
-**Ethical boundary:** Disclose incentives transparently and never reward dishonest reviews -- referrals should benefit referrer, referred, and business alike.
+**Ethical boundary:** Disclose paid incentives in reviews and testimonials (FTC), and reward the referral, never a faked review.
 
-See: [references/referral-systems.md](references/referral-systems.md) for program design, partnership models, and scripts.
+See [references/referral-systems.md](references/referral-systems.md) when designing the referral program -- it has program design, partnership models, and ask scripts.
 
 ## Direct Response Principles
 
-Cross-cutting principles that apply across all nine squares:
+The direct-response doctrine that underpins all nine squares -- every campaign should satisfy these:
 
-| Principle | Description | Application |
-|-----------|-------------|-------------|
-| Trackable | Every marketing action measurable | Unique URLs, phone numbers, promo codes per channel |
-| Measurable | Know the ROI of every dollar | CAC, LTV, conversion rates per channel and campaign |
-| Compelling headlines | Lead with the desired outcome | Benefit-driven headlines, not product features |
-| Specific audience | Speak to one person, not everyone | Niche-specific language, examples, references |
-| Specific offer | Tell people exactly what to do next | "Download the guide," "Book your call," "Start your trial" |
-| Demands a response | Create a reason to act now | Genuine deadlines, limited availability, fast-action bonuses |
-| Multi-step follow-up | One touch is never enough | Automated sequences across email, retargeting, phone, mail |
-| Value first | Lead with generosity, not a pitch | Free content, tools, assessments before asking for money |
-| Has a backend | Real profit is in the second and third sale | Design the product ladder before the first campaign |
+| Principle | What it demands in practice |
+|-----------|-----------------------------|
+| Trackable & measurable | Unique URLs, numbers, and promo codes per channel so you know CAC, LTV, and ROI of every dollar |
+| Compelling headline | Lead with the desired outcome, not product features |
+| Specific offer | Tell people exactly what to do next -- "Download the guide," "Book your call," "Start your trial" |
+| Demands a response | Give a real reason to act now: genuine deadline, limited availability, fast-action bonus |
+| Has a backend | Real profit is the second and third sale -- design the product ladder before the first campaign |
 
 ## Common Mistakes
 
@@ -331,7 +317,7 @@ Cross-cutting principles that apply across all nine squares:
 |---------|-------------|-----|
 | Targeting everyone | Dilutes message, inflates acquisition cost | Use the PVP Index to pick one niche and dominate it first |
 | No USP — competing on price | Attracts price-shoppers, destroys margins | Build a genuine USP: specialization, unique mechanism, or bold guarantee |
-| Brand awareness ads with no tracking | No ROI accountability; money disappears | Apply direct response to every ad: track, measure, call to action |
+| Brand awareness ads with no tracking | No ROI accountability; money disappears | Apply the Direct Response Principles to every ad |
 | Sending traffic to the home page | 97% of visitors aren't ready to buy and leave forever | Use lead magnets and dedicated landing pages |
 | Ignoring existing customers | Misses the highest-ROI marketing (retention, upsells) | Build the AFTER phase: experience, LTV, referrals |
 | No follow-up system | Leads go cold; money left on the table | Automate nurture sequences in a CRM from day one |
@@ -346,19 +332,6 @@ Cross-cutting principles that apply across all nine squares:
 | Do you have a lead magnet converting at 20%+ on its landing page? | Lead capture is underperforming | Test new lead magnets; optimize the opt-in page |
 | Do you have an automated 5+ email sequence for new leads? | Leads go cold without nurture | Build a welcome sequence from the nurture templates |
 | Do you proactively ask for referrals with a script and system? | Your best channel is left to chance | Design a referral program from the referral frameworks |
-
-## Reference Files
-
-- [target-market.md](references/target-market.md) — PVP Index scoring, ideal customer avatar worksheet, niche selection framework
-- [craft-message.md](references/craft-message.md) — USP creation process, elevator pitch formula, commodity trap avoidance
-- [advertising-media.md](references/advertising-media.md) — Direct response channel selection, CAC tracking, organic vs paid, attribution
-- [capture-leads.md](references/capture-leads.md) — Lead magnet types, CRM setup, opt-in page design, speed-to-lead, lead scoring
-- [nurture-leads.md](references/nurture-leads.md) — Email sequence templates, content cadence, multi-channel nurture, segmentation
-- [sales-conversion.md](references/sales-conversion.md) — Pricing psychology, risk reversal, objection handling, sales call structure, proposals
-- [customer-experience.md](references/customer-experience.md) — Moments of truth, NPS, surprise and delight, tribes and community
-- [lifetime-value.md](references/lifetime-value.md) — LTV formulas, ascension model design, reactivation campaigns, raising prices
-- [referral-systems.md](references/referral-systems.md) — Referral program design, partnerships, affiliate programs, scripts, tracking
-- [one-page-plan-template.md](references/one-page-plan-template.md) — Blank 9-square template with prompts, two worked examples, planning exercise
 
 ## Further Reading
 

--- a/pragmatic-programmer/SKILL.md
+++ b/pragmatic-programmer/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: pragmatic-programmer
-description: 'Apply meta-principles of software craftsmanship: DRY, orthogonality, tracer bullets, and design by contract. Use when the user mentions "best practices", "pragmatic approach", "broken windows", "tracer bullet", "software craftsmanship", "technical debt prevention", "code ownership", "how do I become a better developer", "level up my engineering", "avoid technical debt", or "work more effectively as a dev". Also trigger when evaluating build-vs-buy decisions, designing estimation approaches, or choosing between reversible and irreversible architectural decisions. Covers estimation, domain languages, and reversibility. For code-level quality, see clean-code. For refactoring techniques, see refactoring-patterns.'
+description: 'Apply meta-principles of software craftsmanship: DRY, orthogonality, tracer bullets, and design by contract. Use when the user mentions "best practices", "pragmatic approach", "broken windows", "tracer bullet", "software craftsmanship", "avoid technical debt", "code ownership", or "how do I become a better developer". Also trigger when evaluating build-vs-buy decisions, designing estimation approaches, or choosing between reversible and irreversible architectural decisions. Covers estimation, domain languages, and reversibility. For code-level quality, see clean-code. For refactoring techniques, see refactoring-patterns.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # The Pragmatic Programmer Framework
@@ -17,11 +17,16 @@ A systems-level approach to software craftsmanship from Hunt & Thomas' "The Prag
 
 ## Scoring
 
-**Goal: 10/10.** Rate software designs, architecture, or code 0-10 based on adherence to the principles below; a 10/10 means full alignment, lower scores indicate gaps to address. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score against the seven Quick Diagnostic rows: award ~1.4 points per row answered "yes" (7 yes = 10). Then band the result:
+- **9-10**: every principle holds -- DRY knowledge, orthogonal layers, a working tracer slice, contracts at boundaries, no broken windows, reversible vendor/DB choices, ranged estimates.
+- **5-6**: 1-2 violations that cost real change-effort (e.g. business logic coupled to the DB, single-point estimates).
+- **<=3**: pervasive duplication, global state, or accumulated broken windows -- entropy is winning.
 
-## The Pragmatic Programmer Framework
+Always state the score, name the failing diagnostic rows, and give the specific fix from the Action column to reach 10/10.
 
-Seven meta-principles for building software that lasts:
+## The Seven Meta-Principles
+
+Seven principles for building software that lasts:
 
 ### 1. DRY (Don't Repeat Yourself)
 
@@ -44,13 +49,13 @@ Seven meta-principles for building software that lasts:
 | **Validation rules** | Shared schema | One JSON Schema or Zod schema for client and server |
 | **API contracts** | Generate from spec | OpenAPI spec generates types, docs, and client code |
 
-See: [references/dry-orthogonality.md](references/dry-orthogonality.md) for the four duplication types and orthogonal design in depth.
+See: [references/dry-orthogonality.md](references/dry-orthogonality.md) when classifying a specific duplication or deciding whether two code blocks are truly the same knowledge -- per-type examples and mitigations for the four duplication types.
 
 ### 2. Orthogonality
 
 **Core concept:** Two components are orthogonal if changes in one do not affect the other. Design systems where components are self-contained, independent, and have a single, well-defined purpose.
 
-**Why it works:** Orthogonal systems are easier to test, easier to change, and produce fewer side effects. Change the database layer and the UI should not break; change the auth provider and business logic should not care.
+**Why it works:** Decoupling localizes change -- a fix in one module can't ripple into unrelated ones, so blast radius stays bounded. Change the database layer and the UI should not break; change the auth provider and business logic should not care.
 
 **Key insights:**
 - Ask: "If I dramatically change the requirements behind a function, how many modules are affected?" The answer should be one
@@ -66,6 +71,8 @@ See: [references/dry-orthogonality.md](references/dry-orthogonality.md) for the 
 | **Architecture** | Layered separation | Controller -> Service -> Repository, each replaceable |
 | **Dependencies** | Dependency injection | Pass a `Notifier` interface, not a `SlackClient` concrete class |
 | **Testing** | Isolated unit tests | Test business logic without database, network, or filesystem |
+
+See: [references/dry-orthogonality.md](references/dry-orthogonality.md) when measuring coupling or refactoring toward decoupled layers -- the change-impact and stranger tests, layered-architecture diagram, and the helicopter analogy.
 
 ### 3. Tracer Bullets and Prototypes
 
@@ -88,7 +95,7 @@ See: [references/dry-orthogonality.md](references/dry-orthogonality.md) for the 
 | **Uncertain tech** | Spike prototype | Test WebSocket performance before committing |
 | **Microservice** | Walking skeleton | Hello-world service through the full CI/CD pipeline |
 
-See: [references/tracer-bullets.md](references/tracer-bullets.md) for tracer vs. prototype decisions and walking skeletons.
+See: [references/tracer-bullets.md](references/tracer-bullets.md) when deciding tracer vs. prototype on a new project or building a walking skeleton -- the shooting-in-the-dark decision, iteration loop, and common pitfalls.
 
 ### 4. Design by Contract and Assertive Programming
 
@@ -112,7 +119,7 @@ See: [references/tracer-bullets.md](references/tracer-bullets.md) for tracer vs.
 | **Class state** | Invariant validation | `validate!` called after every state mutation |
 | **API boundary** | Schema validation | Validate request body against schema before processing |
 
-See: [references/contracts-assertions.md](references/contracts-assertions.md) for contract patterns and assertive programming.
+See: [references/contracts-assertions.md](references/contracts-assertions.md) when adding contracts to a routine or deciding assertion vs. error handling -- worked pre/post/invariant patterns, dynamic-language guard clauses, and the assertions-vs-error-handling boundary.
 
 ### 5. The Broken Window Theory
 
@@ -135,7 +142,7 @@ See: [references/contracts-assertions.md](references/contracts-assertions.md) fo
 | **Code review** | Zero-tolerance for new debt | Reject PRs adding `// TODO: fix later` without a ticket |
 | **Tech debt** | Debt budget | Allocate 20% of each sprint to fixing broken windows |
 
-See: [references/broken-windows.md](references/broken-windows.md) for entropy fighting and the stone soup strategy.
+See: [references/broken-windows.md](references/broken-windows.md) when a team is normalizing neglect or you need to drive a turnaround -- repair strategies, the stone-soup catalyst play, and building a culture of quality.
 
 ### 6. Reversibility and Flexibility
 
@@ -158,7 +165,7 @@ See: [references/broken-windows.md](references/broken-windows.md) for entropy fi
 | **External API** | Adapter/wrapper | `PaymentGateway` interface wraps Stripe; swap to Braintree later |
 | **Feature flags** | Runtime toggles | New checkout flow behind a flag, rollback in seconds |
 
-See: [references/reversibility.md](references/reversibility.md) for decoupling strategies and avoiding vendor lock-in.
+See: [references/reversibility.md](references/reversibility.md) when committing to a vendor or framework, or weighing how reversible a decision must be -- per-layer reversibility patterns, the forking-road test, and when NOT to optimize for reversibility.
 
 ### 7. Estimation and Knowledge Portfolio
 
@@ -181,7 +188,7 @@ See: [references/reversibility.md](references/reversibility.md) for decoupling s
 | **New technology** | Time-boxed spike | "2 days evaluating; then I can estimate properly" |
 | **Learning** | Weekly investment | 1 hour/week on a new language, tool, or domain |
 
-See: [references/estimation-portfolio.md](references/estimation-portfolio.md) for PERT and portfolio management.
+See: [references/estimation-portfolio.md](references/estimation-portfolio.md) when producing an estimate you'll be held to or calibrating past misses -- the PERT and decomposition procedures, an estimation-log calibration loop, and portfolio rebalancing.
 
 ## Common Mistakes
 
@@ -206,15 +213,6 @@ See: [references/estimation-portfolio.md](references/estimation-portfolio.md) fo
 | Do my estimates include ranges and confidence levels? | Estimation problem | Switch to PERT or range-based estimates |
 | Can I roll back this deployment in under 5 minutes? | Reversibility gap | Add feature flags and blue-green deploys |
 | Am I learning something new every week? | Knowledge portfolio stagnant | Schedule weekly learning time and track it |
-
-## Reference Files
-
-- [references/dry-orthogonality.md](references/dry-orthogonality.md) -- DRY knowledge vs. code duplication, four types of duplication, orthogonality in design and testing
-- [references/tracer-bullets.md](references/tracer-bullets.md) -- Tracer bullet vs. prototype development, building walking skeletons, iterating on tracer code
-- [references/contracts-assertions.md](references/contracts-assertions.md) -- Design by Contract, preconditions/postconditions/invariants, assertive programming patterns
-- [references/broken-windows.md](references/broken-windows.md) -- Software entropy, broken window theory, stone soup strategy, fighting degradation
-- [references/reversibility.md](references/reversibility.md) -- Flexible architecture, decoupling strategies, avoiding vendor lock-in, forking road decisions
-- [references/estimation-portfolio.md](references/estimation-portfolio.md) -- PERT estimation, decomposition techniques, knowledge portfolio management
 
 ## Further Reading
 

--- a/predictable-revenue/SKILL.md
+++ b/predictable-revenue/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: predictable-revenue
-description: 'Build a scalable outbound B2B sales process with specialized roles (SDR, AE, CSM). Use when the user mentions "outbound sales", "Cold Calling 2.0", "prospecting emails", "sales pipeline", "SDR process", "B2B SaaS sales", "sales development", "pipeline velocity", "build an outbound sales team", "fill my sales pipeline", or "cold outreach that actually works". Also trigger when setting up a sales team from scratch, designing cold-email sequences, or building qualification frameworks to improve close rates. Covers lead generation, qualification frameworks, and separating prospecting from closing. For offer design, see hundred-million-offers. For persuasion science, see influence-psychology.'
+description: 'Build a scalable outbound B2B sales machine with specialized roles (SDR, AE, CSM). Use when the user mentions "outbound sales", "Cold Calling 2.0", "cold email sequences", "sales pipeline", "SDR process", "sales development", "build an outbound sales team", or "fill my pipeline". Also trigger when setting up a B2B SaaS sales team from scratch or building a lead-qualification framework to improve close rates. Covers the three lead types (seeds/nets/spears), role specialization, the referral-email method, ANUM qualification, and pipeline math. For offer design, see hundred-million-offers. For persuasion science, see influence-psychology.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Predictable Revenue Framework
@@ -17,7 +17,7 @@ A systematic approach to building a scalable, predictable B2B sales machine — 
 
 ## Scoring
 
-**Goal: 10/10.** Rate any sales process 0-10 on predictability, specialization, and process maturity: 10/10 means clear role separation, repeatable prospecting, and predictable pipeline generation; lower scores mean ad-hoc sales or reliance on heroics. Always give the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score a sales process 0-10 by awarding 2 points for each of the five [Quick Diagnostic](#quick-diagnostic) rows it satisfies (prospecting/closing separated, defined outbound process, 3-month pipeline predictability, known lead-type mix, standardized SDR→AE handoff). Bands: **9-10** = role separation plus a repeatable process that predicts pipeline; **5-6** = some specialization but ad-hoc prospecting or unpredictable pipeline; **≤3** = one person prospects and closes, revenue depends on heroics. Always give the current score and the specific diagnostic rows blocking 10/10.
 
 ## The Three Types of Leads
 
@@ -31,7 +31,7 @@ A systematic approach to building a scalable, predictable B2B sales machine — 
 
 **Key insight:** Most companies over-invest in nets and under-invest in spears; seeds are the best but can't be manufactured quickly. Invest accordingly — customer success and referral programs (seeds), content and paid acquisition (nets), SDR team (spears).
 
-See: [references/lead-types.md](references/lead-types.md) for lead source strategy and investment allocation.
+See [references/lead-types.md](references/lead-types.md) when deciding where to invest — it sizes the seeds/nets/spears budget split by company stage.
 
 ## Sales Role Specialization
 
@@ -58,7 +58,7 @@ Retain and grow accounts: onboard, drive adoption, surface expansion opportuniti
 
 **The virtuous cycle:** SDR generates pipeline → AE closes → CSM retains/grows → happy customer refers (Seeds).
 
-See: [references/roles.md](references/roles.md) for role definitions, career paths, and hiring profiles.
+See [references/roles.md](references/roles.md) when defining a new role or org chart — it has full charters, career paths, and hiring profiles for each role.
 
 ## Cold Calling 2.0
 
@@ -74,22 +74,7 @@ Define your Ideal Customer Profile (company size, industry, tech stack, geograph
 
 ### Step 2: The Referral Email
 
-**The core innovation: don't email the decision maker — email above them and ask for a referral down.** Senior people forward emails, and referrals get 3-5x higher response because the introduction comes from inside the company.
-
-**Subject:** Quick question
-
-> Hi [Name],
->
-> I'm not sure if you're the right person to speak to about [specific topic] at [Company], but I was hoping you could point me to the right person.
->
-> We help [companies like theirs] with [specific value prop].
->
-> Would you mind pointing me to the right person to talk to?
->
-> Thanks,
-> [Your name]
-
-Keep it short (<100 words), no pitch, no attachments or links; ask for a referral, not a meeting; make it easy to forward. Response rate: 9-15% vs. 1-3% for traditional cold emails.
+**The core innovation: don't email the decision maker — email above them and ask for a referral down.** Senior people forward emails, and referrals get 3-5x higher response because the introduction comes from inside the company. The email asks one thing — "who is the right person?" — under 100 words, no pitch, no attachments, no links, easy to forward. Response rate: 9-15% vs. 1-3% for traditional cold emails. For the verbatim template, subject-line open-rate table, and the full Day 1/3/7/14/30 sequence bodies, open [references/cold-calling-2.md](references/cold-calling-2.md).
 
 ### Step 3: Follow Up
 
@@ -101,13 +86,7 @@ Keep it short (<100 words), no pitch, no attachments or links; ask for a referra
 | 14 | Break-up email ("Should I close your file?") |
 | 30 | Re-engage (new trigger event or content) |
 
-Break-up emails work because people respond to losing the opportunity (scarcity):
-
-> Hi [Name],
->
-> I haven't heard back from you. I don't want to be a pest.
->
-> Should I close your file, or would it make sense to chat?
+The **break-up email** on Day 14 often draws the highest response in the sequence — people respond to losing the opportunity (scarcity).
 
 ### Step 4: Qualify with ANUM
 
@@ -124,9 +103,9 @@ Call structure: rapport (2 min) → set agenda ("understand your situation, see 
 
 Include account background and ICP match, contact details and role, pain points, ANUM notes, agreed next steps, and competitive intel. SDR introduces AE on a brief 3-way call or email, then drops off.
 
-**Ethical boundary:** Comply with spam laws (CAN-SPAM, GDPR), honor opt-outs immediately, and represent your offer honestly — referral emails work because they're genuine requests, not tricks.
+**Ethical boundary:** Comply with spam laws (CAN-SPAM, GDPR) and honor opt-outs immediately — including removing a hostile "stop emailing me" from the sequence on the spot, not at the next scheduled touch.
 
-See: [references/cold-calling-2.md](references/cold-calling-2.md) for email templates, sequences, and scripts; [references/qualification.md](references/qualification.md) for ANUM discovery questions.
+See [references/qualification.md](references/qualification.md) when running the ANUM discovery call — it has the full discovery question bank per criterion.
 
 ## Pipeline Math
 
@@ -149,9 +128,11 @@ Prospects Needed ÷ Response Rate = Emails Needed
 | AE demo-to-close rate | 20-30% |
 | Average sales cycle | 30-90 days |
 
-See: [references/pipeline-math.md](references/pipeline-math.md) for revenue modeling templates.
+See [references/pipeline-math.md](references/pipeline-math.md) when sizing the SDR team to a revenue target — it has the full capacity-planning and revenue-modeling templates.
 
 ## Building the Sales Development Team
+
+See [references/case-studies.md](references/case-studies.md) when you want a worked precedent for standing up or scaling the machine — it walks through Salesforce, HubSpot, and other implementations with starting state, results, and failure modes.
 
 ### Hiring SDRs
 
@@ -172,7 +153,7 @@ Expect 3-4 months to full productivity.
 
 Base + variable, typically 60/40 or 70/30. Pay variable per qualified opportunity generated, with bonuses for opportunities that close and for exceeding quota.
 
-See: [references/team-building.md](references/team-building.md) for hiring, onboarding, and compensation detail.
+See [references/team-building.md](references/team-building.md) when hiring or building the comp plan — it has interview scorecards, the onboarding curriculum, and detailed compensation structures.
 
 ## Metrics and Dashboards
 
@@ -190,7 +171,7 @@ Cost per qualified opportunity, SDR:AE ratio (typically 2-3 SDRs per AE), LTV:CA
 
 **Cadence:** daily activity metrics → weekly pipeline → monthly revenue → quarterly efficiency.
 
-See: [references/metrics.md](references/metrics.md) for dashboard templates.
+See [references/metrics.md](references/metrics.md) when building the sales dashboard — it has KPI definitions, formulas, and dashboard layouts by cadence.
 
 ## Common Mistakes
 
@@ -214,17 +195,6 @@ Audit any B2B sales process:
 | Can you predict pipeline 3 months out? | Revenue is unpredictable | Build pipeline math model |
 | Do you know your lead type mix? | Over-reliance on one source | Balance seeds, nets, spears |
 | Is SDR→AE handoff standardized? | Leads lost in transition | Create handoff checklist |
-
-## Reference Files
-
-- [lead-types.md](references/lead-types.md): Seeds, nets, spears strategy and investment
-- [roles.md](references/roles.md): SDR, MDR, AE, CSM role definitions and hiring
-- [cold-calling-2.md](references/cold-calling-2.md): Email templates, sequences, follow-up cadence
-- [pipeline-math.md](references/pipeline-math.md): Revenue modeling, capacity planning
-- [team-building.md](references/team-building.md): Hiring, onboarding, compensation, career paths
-- [metrics.md](references/metrics.md): Dashboard templates, KPI tracking
-- [qualification.md](references/qualification.md): ANUM framework, discovery questions
-- [case-studies.md](references/case-studies.md): Salesforce, HubSpot, and scaling stories
 
 ## Further Reading
 

--- a/refactoring-patterns/SKILL.md
+++ b/refactoring-patterns/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: refactoring-patterns
-description: 'Apply named refactoring transformations to improve code structure without changing behavior. Use when the user mentions "refactor this", "code smells", "extract method", "replace conditional", "technical debt", "move method", "inline variable", "decompose conditional", "clean up this messy code", "restructure without breaking anything", or "this code needs reorganizing". Also trigger when cleaning up legacy code, preparing code for new features by restructuring, or identifying which transformation fits a specific code smell. Covers smell-driven refactoring, safe transformation sequences, and testing guards. For code-quality foundations, see clean-code. For managing complexity, see software-design-philosophy.'
+description: 'Apply named refactoring transformations to improve code structure without changing behavior. Use when the user mentions "refactor this", "code smells", "extract method", "replace conditional", "technical debt", "move method", "inline variable", "decompose conditional", or "clean up this messy code". Also trigger when cleaning up legacy code, preparing code for new features by restructuring, or identifying which transformation fits a specific code smell. Covers smell-driven refactoring, safe transformation sequences, and testing guards. For code-quality foundations, see clean-code. For managing complexity, see software-design-philosophy.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Refactoring Patterns Framework
@@ -19,7 +19,12 @@ A disciplined approach to improving the internal structure of existing code with
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or refactoring code, rate structural quality 0-10: a 10/10 means no obvious smells remain, each function does one thing, names reveal intent, duplication is eliminated, and tests cover the refactored paths. Always give the current score and the specific refactorings needed to reach 10/10.
+**Goal: 10/10.** Score structural quality by counting satisfied rows in the [Quick Diagnostic](#quick-diagnostic) (8 rows): roughly one point per satisfied row, plus margin for severity. Bands:
+- **9-10**: no obvious smells remain, each function does one thing, names reveal intent, duplication is eliminated, conditionals use polymorphism where apt, and tests cover the refactored paths.
+- **5-6**: a few smells remain (a Long Method, some duplication) but structure is mostly sound.
+- **≤3**: pervasive smells — tangled conditionals, God classes, duplication everywhere — or no tests to refactor safely.
+
+Always state the current score, name the smells driving it down, and list the specific refactorings needed to reach 10/10.
 
 ## The Refactoring Patterns Framework
 
@@ -43,11 +48,11 @@ Six areas of focus for systematically improving code structure:
 | Context | Pattern | Example |
 |---------|---------|---------|
 | Method > 10 lines | Extract Method | Pull loop body into `calculateLineTotal()` |
-| Switch on type code | Replace Conditional with Polymorphism | Subclass per order type |
+| One change touches many classes (Shotgun Surgery) | Move Method/Field | Gather the scattered behavior into one class |
 | Same params in many methods | Introduce Parameter Object | `startDate, endDate` → `DateRange` |
 | Copy-pasted logic | Extract Method + Pull Up Method | Share via common method or base class |
 
-See: [references/smell-catalog.md](references/smell-catalog.md) when you need the full smell-to-refactoring mapping.
+See [references/smell-catalog.md](references/smell-catalog.md) when you need to name a smell and its fix — all five families (Bloaters, OO Abusers, Change Preventers, Dispensables, Couplers) with detection heuristics and the refactoring each maps to.
 
 ### 2. Composing Methods
 
@@ -71,13 +76,13 @@ See: [references/smell-catalog.md](references/smell-catalog.md) when you need th
 | Trivial delegating method | Inline Method | Inline `return deliveries > 5` if used once |
 | Method with many tangled locals | Replace Method with Method Object | Locals become fields in a new class |
 
-See: [references/composing-methods.md](references/composing-methods.md) for mechanics and worked examples of each.
+See [references/composing-methods.md](references/composing-methods.md) when applying any method-level transformation — step-by-step mechanics and before/after code for Extract/Inline Method, Extract/Inline Variable, Replace Temp with Query, Split Temporary Variable, and Replace Method with Method Object.
 
 ### 3. Moving Features Between Objects
 
 **Core concept:** The key OO design decision is where responsibilities live. When Feature Envy, excessive coupling, or unbalanced class sizes show a method or field is in the wrong class, move it where it belongs.
 
-**Why it works:** When a method lives with the data it uses, changes affect one class; misplaced methods create invisible dependencies that cause Shotgun Surgery.
+**Why it works:** A method placed away from the data it uses creates invisible cross-class dependencies, so one logical change ripples across many files — Shotgun Surgery. Co-locating method and data confines the change to one class.
 
 **Key insights:**
 - Move Method when a method uses more of another class's features than its own; Move Field likewise
@@ -94,7 +99,7 @@ See: [references/composing-methods.md](references/composing-methods.md) for mech
 | Client calls `a.getB().getC()` | Hide Delegate | Add `a.getCThroughB()` |
 | Class only forwards calls | Remove Middle Man | Let client call the delegate directly |
 
-See: [references/moving-features.md](references/moving-features.md) when deciding where a responsibility belongs.
+See [references/moving-features.md](references/moving-features.md) when deciding where a responsibility belongs — mechanics for Move Method/Field, Extract/Inline Class, Hide Delegate, and Remove Middle Man.
 
 ### 4. Organizing Data
 
@@ -118,7 +123,7 @@ See: [references/moving-features.md](references/moving-features.md) when decidin
 | Getter returns mutable list | Encapsulate Collection | Return `Collections.unmodifiableList(items)` |
 | `int typeCode` with switch | Replace Type Code with Subclasses | `Employee` → `Engineer`, `Manager` |
 
-See: [references/organizing-data.md](references/organizing-data.md) for the full data-refactoring catalog.
+See [references/organizing-data.md](references/organizing-data.md) when replacing primitives with objects — mechanics for Replace Data Value with Object, Change Value to Reference, Replace Magic Number, Encapsulate Field/Collection, and the Replace Type Code variants.
 
 ### 5. Simplifying Conditional Logic
 
@@ -142,7 +147,7 @@ See: [references/organizing-data.md](references/organizing-data.md) for the full
 | Switch on object type | Replace Conditional with Polymorphism | Each type implements its own `calculatePay()` |
 | `if (customer == null)` everywhere | Introduce Special Case | `NullCustomer` with safe default behavior |
 
-See: [references/simplifying-conditionals.md](references/simplifying-conditionals.md) for before/after examples.
+See [references/simplifying-conditionals.md](references/simplifying-conditionals.md) when untangling branches — before/after examples for Decompose/Consolidate Conditional, Guard Clauses, Replace Conditional with Polymorphism, Special Case, and Assertions.
 
 ### 6. Safe Refactoring Workflow
 
@@ -166,7 +171,7 @@ See: [references/simplifying-conditionals.md](references/simplifying-conditional
 | Large API change in production | Branch by Abstraction | Add abstraction layer, migrate callers, remove old path |
 | Renaming a widely-used method | Parallel Change | Add new, deprecate old, migrate, remove |
 
-See: [references/refactoring-workflow.md](references/refactoring-workflow.md) for the full cycle and when-to-refactor guidance.
+See [references/refactoring-workflow.md](references/refactoring-workflow.md) before a large or risky refactoring — the full green-to-green cycle, when (not) to refactor, performance, Branch by Abstraction, and Parallel Change.
 
 ## Common Mistakes
 
@@ -193,15 +198,6 @@ See: [references/refactoring-workflow.md](references/refactoring-workflow.md) fo
 | Do conditionals use polymorphism where apt? | Switch Statements remain | Replace Conditional with Polymorphism |
 | Are you committing after each step? | Risk losing work, mixing changes | Commit after every green-to-green transformation |
 | Is the code easier to read after your change? | Refactoring added complexity | Revert and try a different approach |
-
-## Reference Files
-
-- [smell-catalog.md](references/smell-catalog.md): All smell families (Bloaters, OO Abusers, Change Preventers, Dispensables, Couplers) with detection heuristics and fix mappings
-- [composing-methods.md](references/composing-methods.md): Extract/Inline Method, Extract/Inline Variable, Replace Temp with Query, Split Temporary Variable, Replace Method with Method Object
-- [moving-features.md](references/moving-features.md): Move Method/Field, Extract/Inline Class, Hide Delegate, Remove Middle Man
-- [organizing-data.md](references/organizing-data.md): Replace Data Value with Object, Change Value to Reference, Replace Magic Number, Encapsulate Field/Collection, Replace Type Code variants
-- [simplifying-conditionals.md](references/simplifying-conditionals.md): Decompose/Consolidate Conditional, Guard Clauses, Replace Conditional with Polymorphism, Special Case, Assertions
-- [refactoring-workflow.md](references/refactoring-workflow.md): The refactoring cycle, when (not) to refactor, performance, Branch by Abstraction, Parallel Change
 
 ## Further Reading
 

--- a/refactoring-patterns/SKILL.md
+++ b/refactoring-patterns/SKILL.md
@@ -4,7 +4,7 @@ description: 'Apply named refactoring transformations to improve code structure 
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # Refactoring Patterns Framework
@@ -19,7 +19,7 @@ A disciplined approach to improving the internal structure of existing code with
 
 ## Scoring
 
-**Goal: 10/10.** Score structural quality by counting satisfied rows in the [Quick Diagnostic](#quick-diagnostic) (8 rows): roughly one point per satisfied row, plus margin for severity. Bands:
+**Goal: 10/10.** Score structural quality by how many of the eight [Quick Diagnostic](#quick-diagnostic) rows pass — `score = round(passed / 8 × 10)`, adjusting down when a single smell is severe. Bands:
 - **9-10**: no obvious smells remain, each function does one thing, names reveal intent, duplication is eliminated, conditionals use polymorphism where apt, and tests cover the refactored paths.
 - **5-6**: a few smells remain (a Long Method, some duplication) but structure is mostly sound.
 - **≤3**: pervasive smells — tangled conditionals, God classes, duplication everywhere — or no tests to refactor safely.

--- a/refactoring-ui/SKILL.md
+++ b/refactoring-ui/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: refactoring-ui
-description: 'Audit and fix visual hierarchy, spacing, color, and depth in web UIs. Use when the user mentions "my UI looks off", "make it look better", "this looks amateur", "looks unprofessional", "fix the design", "Tailwind styling", "color palette", "visual hierarchy", "design system", "spacing scale", or "component styling". Also trigger when building consistent design tokens, creating dark mode themes, improving data-visualization clarity, or polishing UI details before launch. Covers grayscale-first workflow, constrained design scales, shadows, and component styling. For typeface selection, see web-typography. For usability audits, see ux-heuristics.'
+description: 'Audit and fix visual hierarchy, spacing, color, and depth in web UIs. Use when the user mentions "my UI looks off" (or amateur/unprofessional), "fix the design", "Tailwind styling", "color palette", "visual hierarchy", "design system", "spacing scale", or "component styling". Also trigger when building consistent design tokens, creating dark mode themes, improving data-visualization clarity, or polishing UI details before launch. Covers grayscale-first workflow, constrained design scales, shadows, and component styling. For typeface selection, see web-typography. For usability audits, see ux-heuristics.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Refactoring UI Design System
@@ -19,7 +19,7 @@ A practical, opinionated approach to UI design. Apply these principles when gene
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating UI designs or frontend code, rate 0-10 against the principles below — 10/10 means full alignment, lower scores indicate gaps. Always give the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score by counting satisfied rows in the [Quick Diagnostic](#quick-diagnostic) (8 yes/no checks): `score = round(satisfied / 8 × 10)`. Bands follow directly: **10** = all 8 pass (hierarchy reads blurred and in grayscale, every value on a scale); **9** = exactly 1 gap (usually weak hierarchy or thin white space); **6-8** = 2-3 gaps; **<=5** = 4+ gaps (arbitrary spacing, color doing the work hierarchy should, or failing contrast). Always state the current score and the specific diagnostic rows to fix to reach 10/10.
 
 ## The Refactoring UI Framework
 
@@ -50,7 +50,7 @@ Seven principles for building professional interfaces without a designer:
 
 **Ethical boundary:** Don't use hierarchy tricks to hide important information like pricing, terms, or cancellation options.
 
-See: [references/advanced-patterns.md](references/advanced-patterns.md) for interaction states, form design, empty states, and responsive patterns.
+See [references/advanced-patterns.md](references/advanced-patterns.md) when designing components beyond static layout — interaction/hover/focus states, form design, empty states, border-radius systems, text truncation, and responsive breakpoints.
 
 ### 2. Spacing & Sizing
 
@@ -77,16 +77,14 @@ See: [references/advanced-patterns.md](references/advanced-patterns.md) for inte
 - `max-w-prose`(65ch) `max-w-md`(28rem) `max-w-lg`(32rem) `max-w-xl`(36rem)
 - `gap-2` for related items, `gap-6` for section separation
 
-**Ethical boundary:** Don't use spacing to bury important UI elements like unsubscribe buttons or privacy controls.
-
 ### 3. Typography
 
 **Core concept:** Use a modular type scale, constrain line heights by context, and limit to two font families maximum.
 
-**Why it works:** A modular scale (e.g., 1.25 ratio) creates natural visual rhythm; tight line heights on headings and relaxed on body text improve readability in each context.
+**Why it works:** A modular scale (steps growing ~1.2× each) creates natural visual rhythm; tight line heights on headings and relaxed on body text improve readability in each context.
 
 **Key insights:**
-- Scale: 12, 14, 16, 20, 24, 30, 36px (1.25 ratio)
+- Scale: 12, 14, 16, 18, 20, 24, 30, 36px (~1.2 modular, hand-tuned)
 - Headings: tight line height (1.0-1.25); body: relaxed (1.5-1.75); wider text needs more line height
 - Avoid weights below 400 for body text; use bold (600-700) for emphasis, not everything
 - Two fonts max: one for headings, one for body (or one family with weight variation)
@@ -103,8 +101,6 @@ See: [references/advanced-patterns.md](references/advanced-patterns.md) for inte
 - `text-xs`(12px) `text-sm`(14px) `text-base`(16px) `text-lg`(18px) `text-xl`(20px)
 - `font-normal`(400) `font-medium`(500) `font-semibold`(600) `font-bold`(700)
 - `leading-tight`(1.25) `leading-normal`(1.5) `leading-relaxed`(1.75)
-
-**Ethical boundary:** Don't use tiny type sizes to hide terms, conditions, or fees from users.
 
 ### 4. Color
 
@@ -131,15 +127,13 @@ See: [references/advanced-patterns.md](references/advanced-patterns.md) for inte
 - `bg-blue-50` for subtle backgrounds, `bg-blue-500` for primary actions
 - `border-gray-200` for subtle borders, `border-gray-300` for stronger
 
-**Ethical boundary:** Don't use color alone to convey information — always pair with text or icons for accessibility.
-
-See: [references/theming-dark-mode.md](references/theming-dark-mode.md) for dark palette creation and theme implementation.
+See [references/theming-dark-mode.md](references/theming-dark-mode.md) when building a dark theme — hex shade scales, why darkest is `#111827` not black (halation), and conveying elevation via lightness instead of shadow. See [references/accessibility-depth.md](references/accessibility-depth.md) when contrast, focus rings, keyboard nav, or screen-reader support is in scope — full WCAG 2.1 AA checklist and fixes.
 
 ### 5. Depth & Shadows
 
 **Core concept:** Use a shadow scale to convey elevation — small shadows for slightly raised elements, large shadows for floating ones.
 
-**Why it works:** Shadows create physical depth that tells users which elements are interactive, floating, or background.
+**Why it works:** The eye reads shadow size as height above the page; a consistent scale makes elevation legible, so users intuit what's interactive, floating, or background.
 
 **Key insights:**
 - Small shadows = raised slightly (buttons, cards); large = floating (modals, dropdowns)
@@ -161,7 +155,7 @@ See: [references/theming-dark-mode.md](references/theming-dark-mode.md) for dark
 - `shadow-lg`: `0 10px 15px rgba(0,0,0,0.1)`
 - `shadow-xl`: `0 20px 25px rgba(0,0,0,0.15)`
 
-**Ethical boundary:** Don't use excessive shadows or visual emphasis to draw attention to deceptive UI elements (dark patterns).
+See [references/animation-microinteractions.md](references/animation-microinteractions.md) when adding motion to interactive elements — durations, easing curves, loading states, and the `prefers-reduced-motion` rule.
 
 ### 6. Images & Icons
 
@@ -188,13 +182,11 @@ See: [references/theming-dark-mode.md](references/theming-dark-mode.md) for dark
 - Icon sizing: `w-4 h-4` inline, `w-6 h-6` navigation, `w-8 h-8` feature icons
 - Overlay: `bg-gradient-to-t from-black/60 to-transparent` for text on images
 
-**Ethical boundary:** Don't use misleading images or icons that misrepresent functionality or product capabilities.
-
 ### 7. Layout & Composition
 
 **Core concept:** Don't center everything. Use alignment, overlap, and emphasis variation to create engaging compositions.
 
-**Why it works:** Left-aligned text is easier to read, and varied layouts that break out of rigid boxes feel dynamic and intentional.
+**Why it works:** A consistent left edge gives the eye a fixed return point per line, so it costs less to scan; centered multi-line text moves that edge every line and slows reading.
 
 **Key insights:**
 - Left-align by default; center only short headlines, heroes, single-action CTAs, and empty states
@@ -215,7 +207,7 @@ See: [references/theming-dark-mode.md](references/theming-dark-mode.md) for dark
 - `grid grid-cols-3 gap-6` for feature grids; `max-w-4xl mx-auto` for page containers
 - `overflow-hidden` on cards with `object-fit: cover` images that bleed to edges
 
-**Ethical boundary:** Don't use layout tricks to hide or obscure important user choices like opt-outs or data permissions.
+See [references/data-visualization.md](references/data-visualization.md) when laying out charts, tables, or dashboards — chart-type selection, color use in charts, table density, and dashboard composition.
 
 ## Common Mistakes
 
@@ -244,14 +236,6 @@ Audit any UI design:
 | Is text width constrained? | Long lines fatigue readers | Apply `max-w-prose` (~65ch) |
 | Do colors have sufficient contrast? | Accessibility failure | WCAG-check; use gray-700+ on white |
 | Are shadows appropriate for elevation? | Elements float at wrong level | Match shadow scale to element purpose |
-
-## Reference Files
-
-- [advanced-patterns.md](references/advanced-patterns.md): Empty states, form design, image treatment, icon sizing, interaction states, color psychology, border radius systems, text truncation, responsive breakpoints
-- [animation-microinteractions.md](references/animation-microinteractions.md): When to animate, easing functions, durations, loading states, animation performance
-- [accessibility-depth.md](references/accessibility-depth.md): WCAG 2.1 AA checklist, focus management, screen reader support, keyboard navigation
-- [data-visualization.md](references/data-visualization.md): Chart selection, color in charts, table design, dashboard layouts
-- [theming-dark-mode.md](references/theming-dark-mode.md): Dark palette creation, elevation in dark mode, theme implementation strategies
 
 ## Further Reading
 

--- a/release-it/SKILL.md
+++ b/release-it/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: release-it
-description: 'Build production-ready systems with stability patterns: circuit breakers, bulkheads, timeouts, and retry logic. Use when the user mentions "production outage", "circuit breaker", "timeout strategy", "deployment pipeline", "chaos engineering", "bulkhead pattern", "retry with backoff", "health checks", "my service keeps crashing", "prevent cascading failures", or "make it resilient". Also trigger when designing resilient microservices, planning zero-downtime deployments, or investigating cascading-failure scenarios. Covers capacity planning, health checks, and anti-fragility patterns. For data systems, see ddia-systems. For system architecture, see system-design.'
+description: 'Build production-ready systems with stability patterns: circuit breakers, bulkheads, timeouts, and retry logic. Use when the user mentions "production outage", "circuit breaker", "deployment pipeline", "chaos engineering", "retry storm", "health checks", "my service keeps crashing", "prevent cascading failures", or "make it resilient". Also trigger when designing resilient microservices, planning zero-downtime deployments, or capacity-planning for peak load. Covers stability patterns, capacity planning, deploy/release decoupling, and observability. For data systems, see ddia-systems. For system architecture, see system-design.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Release It! Framework
@@ -17,7 +17,7 @@ Framework for designing, deploying, and operating production-ready software. The
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating production systems, rate them 0-10 against the principles below — 10/10 means full alignment, lower scores indicate gaps. Always give the current score and the specific improvements needed to reach 10/10.
+**Goal: 8/8.** Score a production system by the Quick Diagnostic: **1 point per row answered "yes"** across the 8 checks (timeouts, circuit breakers, bulkheads, zero-downtime deploy, deep health checks, correlated telemetry, load-tested past peak, failure injection). Bands: **7-8** = every integration point is bounded, isolated, observable, and deploy/release are decoupled; **4-5** = some patterns present but ≥3 diagnostic rows fail (e.g. unbounded retries, shared pools, shallow health checks); **≤2** = relies on the happy path with no breakers, no capacity model, no failure testing. Always state the current score, the failing rows, and the specific fix for each.
 
 ## The Release It! Framework
 
@@ -27,7 +27,7 @@ Six areas that determine whether software survives contact with production:
 
 **Core concept:** Failures propagate through integration points and cascade across system boundaries. The most dangerous patterns are not bugs in your code — they are emergent behaviors when systems interact under stress.
 
-**Why it works:** Every production outage traces back to one or more of these predictable, recurring patterns; recognizing them lets you eliminate the cracks before production traffic finds them.
+**Why it works:** These patterns recur across outages, so audit by name: walk every integration point and ask which anti-pattern it currently enables, then close that specific crack rather than hardening at random.
 
 **Key insights:**
 - Integration points are the number-one killer — every socket, HTTP call, or queue is a risk
@@ -38,20 +38,20 @@ Six areas that determine whether software survives contact with production:
 
 **Code applications:**
 
-| Context | Pattern | Example |
-|---------|---------|---------|
+| Context | Guard | Example |
+|---------|-------|---------|
 | HTTP calls | Assume every remote call can fail, hang, or return garbage | Wrap all external calls with timeout + circuit breaker |
 | Database queries | Enforce result set limits | Add `LIMIT`; paginate all list endpoints |
 | Thread pools | Isolate pools per dependency | Separate pool for payment gateway vs. search |
 | Marketing events | Coordinate launches with capacity planning | Pre-scale before Black Friday; queue coupon redemptions |
 
-See: [references/anti-patterns.md](references/anti-patterns.md) for each anti-pattern with failure scenarios and detection strategies.
+See [references/anti-patterns.md](references/anti-patterns.md) when triaging an outage or hardening an integration point — each anti-pattern with its failure scenario and the symptom that detects it.
 
 ### 2. Stability Patterns
 
 **Core concept:** Counter each anti-pattern with a stability pattern: circuit breakers stop cascades, bulkheads isolate blast radius, timeouts reclaim stuck resources. Together they make a system bend under load instead of breaking.
 
-**Why it works:** These patterns accept failure as inevitable and design the response to it — a circuit breaker that trips is the system working correctly, protecting itself from a downstream failure.
+**Why it works:** Each pattern caps the damage one failure can do: a breaker trip converts an unbounded cascade into a fast local rejection, a bulkhead confines the outage to one pool. Treat a tripped breaker as expected output, not an incident — page on the breaker *staying* open, not on it opening.
 
 **Key insights:**
 - Circuit Breaker: three states (closed, open, half-open) — trips after threshold failures, periodically tests recovery
@@ -71,7 +71,7 @@ See: [references/anti-patterns.md](references/anti-patterns.md) for each anti-pa
 | Retries | Backoff + jitter + budget | Base 100ms, max 3 retries, 20% fleet retry budget |
 | Data cleanup | Steady State | Purge sessions >24h; rotate logs at 500MB |
 
-See: [references/stability-patterns.md](references/stability-patterns.md) for state machines, threshold tuning, and pattern combinations.
+See [references/stability-patterns.md](references/stability-patterns.md) when implementing a breaker or tuning thresholds — state-machine diagram, parameter ranges, what-counts-as-failure tables, and how to combine patterns.
 
 ### 3. Capacity and Availability
 
@@ -94,7 +94,7 @@ See: [references/stability-patterns.md](references/stability-patterns.md) for st
 | Soak testing | 80% capacity for 24-72 hours | Catch memory/connection/file-handle leaks |
 | Capacity model | Document bottleneck per service | "Service X is memory-bound at 2000 RPS; 4GB per instance" |
 
-See: [references/capacity-planning.md](references/capacity-planning.md) for testing methodologies, pool management, and scalability modeling.
+See [references/capacity-planning.md](references/capacity-planning.md) when planning a load test or sizing pools — test methodologies, pool/thread tuning, and Universal Scalability Law modeling.
 
 ### 4. Deployment and Release
 
@@ -118,13 +118,13 @@ See: [references/capacity-planning.md](references/capacity-planning.md) for test
 | Feature launch | Flags with emergency off switch | Ship behind flag; enable for 10%; monitor; ramp |
 | Schema changes | Expand-contract migration | Add column; write both; backfill; drop old |
 
-See: [references/deployment-strategies.md](references/deployment-strategies.md) for deployment patterns, migration strategies, and infrastructure-as-code.
+See [references/deployment-strategies.md](references/deployment-strategies.md) when planning a release or a schema change — blue-green/canary/rolling mechanics, expand-contract migration steps, and infrastructure-as-code.
 
 ### 5. Health Checks and Observability
 
 **Core concept:** You cannot operate what you cannot observe. Health checks, metrics, logs, and traces are the sensory organs of your system in production — a first-class design concern, not an afterthought.
 
-**Why it works:** Production systems fail invisibly without instrumentation. Done right, observability answers questions about your system that you did not anticipate at design time.
+**Why it works:** Untraced failures are invisible until a user reports them. Emit high-cardinality, structured events (not just pre-aggregated counters) so you can ask new questions of past incidents without shipping new instrumentation first.
 
 **Key insights:**
 - Health checks come in two flavors: shallow (process alive) and deep (dependencies reachable, resources available)
@@ -142,7 +142,7 @@ See: [references/deployment-strategies.md](references/deployment-strategies.md) 
 | Distributed tracing | Propagate trace context | Trace ID in headers; correlate logs across services |
 | Alerting | SLO burn rate, not raw thresholds | "Error budget burning 10x" vs. "CPU > 80%" |
 
-See: [references/observability.md](references/observability.md) for health check design, SLO frameworks, and alerting strategies.
+See [references/observability.md](references/observability.md) when instrumenting a service or setting SLOs — health-check design, RED/USE metric sets, the SLI→SLO→SLA chain, and burn-rate alerting.
 
 ### 6. Adaptation and Chaos Engineering
 
@@ -169,7 +169,7 @@ See: [references/observability.md](references/observability.md) for health check
 | Dependency failure | Simulate downstream outage via chaos tooling | Return 503 from payment API; verify graceful degradation |
 | GameDay | Scheduled team exercise | "Primary DB goes read-only at 2pm" — practice response |
 
-See: [references/chaos-engineering.md](references/chaos-engineering.md) for experiment design, blast radius management, and building the practice.
+See [references/chaos-engineering.md](references/chaos-engineering.md) when designing a failure experiment or GameDay — steady-state hypothesis, blast-radius controls, and how to grow the practice from non-prod outward.
 
 ## Common Mistakes
 
@@ -198,15 +198,6 @@ Audit any production system:
 | Are logs, metrics, and traces correlated? | Debugging means manual log searches | Distributed tracing with correlated IDs |
 | Have you load-tested beyond expected peak? | Unknown failure mode under real load | Test to 2-3x peak; document the breaking point |
 | Do you practice failure injection? | Resilience is theoretical | Start chaos engineering with low-risk experiments |
-
-## Reference Files
-
-- [anti-patterns.md](references/anti-patterns.md): Integration point failures, cascading failures, blocked threads, unbounded result sets, self-denial attacks, slow responses
-- [stability-patterns.md](references/stability-patterns.md): Circuit Breaker, Bulkhead, Timeout, Retry, Fail Fast, Steady State, Let It Crash, Handshaking
-- [capacity-planning.md](references/capacity-planning.md): Load/stress/soak testing, connection pool sizing, thread pool tuning, Universal Scalability Law
-- [deployment-strategies.md](references/deployment-strategies.md): Blue-green, canary, rolling deploys, feature flags, database migrations, immutable infrastructure
-- [observability.md](references/observability.md): Health checks, RED/USE methods, SLIs/SLOs/SLAs, distributed tracing, alerting strategy
-- [chaos-engineering.md](references/chaos-engineering.md): Steady state hypothesis, failure injection, GameDay exercises, blast radius management
 
 ## Further Reading
 

--- a/scorecard-marketing/SKILL.md
+++ b/scorecard-marketing/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: scorecard-marketing
-description: 'Build quiz and assessment funnels that generate qualified leads at 30-50% conversion. Use when the user mentions "lead magnet", "quiz funnel", "assessment tool", "lead generation", "score-based segmentation", "interactive content", "lead qualification", "quiz marketing", "build a quiz to get leads", "capture more emails", or "interactive assessment". Also trigger when designing self-assessment tools, building calculators or graders for marketing, or creating personalized result pages that drive conversions. Covers question design, dynamic results by tier, and automated follow-up sequences. For landing page conversion, see cro-methodology. For full marketing plans, see one-page-marketing.'
+description: 'Build quiz and assessment funnels that generate qualified leads at 30-50% conversion. Use when the user mentions "quiz funnel", "scorecard", "lead magnet", "score-based segmentation", or "lead qualification". Also trigger when designing self-assessment tools, building calculators or graders for marketing, or creating personalized result pages that drive conversions. Covers concept hooks, question design, dynamic results by tier, and automated follow-up sequences. For landing page conversion, see cro-methodology. For full marketing plans, see one-page-marketing.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Scorecard Marketing Skill
@@ -15,11 +15,11 @@ A proven 4-step system for generating qualified leads through interactive assess
 
 **Everything is downstream from lead generation.** People buy to resolve psychological tension between their current reality and desired reality — a scorecard awakens dormant desires by asking revealing questions.
 
-**The foundation:** Active searchers are harder to sell to (already decided, set budget); people with dormant desires buy from whoever helped them uncover the need. A well-designed scorecard converts 30-50% of visitors vs. 3-10% for PDF lead magnets, because interactive assessments create psychological engagement static content cannot.
+**The foundation:** Active searchers are harder to sell to (already decided, set budget); people with dormant desires buy from whoever helped them uncover the need. Interactive assessments create psychological engagement static content cannot — which is why they convert several times better than a PDF download (see [Conversion Benchmarks](#conversion-benchmarks)).
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating assessment funnels or quiz landing pages, rate them 0-10 against the principles below — 10/10 means full alignment, lower scores indicate gaps. Always give the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score a funnel against the six [Quick Diagnostic](#quick-diagnostic) rows: `score = round(satisfied_rows / 6 × 10)`. Read the bands as: **9-10** = all six pass (dormant-desire hook, email captured first, scored categories, unique per-tier content and CTA, tier-segmented follow-up); **5-7** = the funnel exists but generic results or late email capture cost it 2-3 rows; **≤3** = no concept hook or no scoring. Always give the current score and the specific rows to close to reach 10/10.
 
 ## The 4-Step Scorecard System
 
@@ -30,7 +30,7 @@ A proven 4-step system for generating qualified leads through interactive assess
 **Why it works:** A concept hook taps a dormant desire; framing around a score triggers the primal drive to measure, rank, and improve. Curiosity plus low commitment ("takes 3 minutes") removes friction.
 
 **Key insights:**
-- The concept hook is the single most important element — it defines what visitors score themselves on
+- The concept hook is the single most important element — it defines what visitors score themselves on. The 5 hook types: **moving toward** (goal), **pain removal**, **readiness** (decision validation), **category** (compare yourself to a standard), **knowledge** (test what you know)
 - "Moving toward" hooks ("Are you ready to [goal]?") outperform fear-based hooks
 - The 3 Cs — Clarity, Credibility, Connection — must all be present
 - Bonuses (free book, consultation, report) lift completion; a time expectation ("less than 3 minutes") reduces abandonment
@@ -50,7 +50,7 @@ A proven 4-step system for generating qualified leads through interactive assess
 
 **Ethical boundary:** The hook must promise value the assessment actually delivers — never bait-and-switch into a sales pitch disguised as results.
 
-See: [references/industry-examples.md](references/industry-examples.md) for 50+ scorecard concepts and landing page hooks across industries.
+See [references/industry-examples.md](references/industry-examples.md) when you need a starting hook for a specific niche — 50+ scorecard concepts and landing-page headlines across industries.
 
 ### 2. Questionnaire
 
@@ -78,9 +78,9 @@ See: [references/industry-examples.md](references/industry-examples.md) for 50+ 
 - Progress indicators ("Question 5 of 12") reduce abandonment; "Almost done!" maintains momentum
 - Category names should be meaningful to the respondent, not internal jargon
 
-**Ethical boundary:** Never disguise sales qualification as helpful assessment — qualifying questions should be transparently useful to both parties, and don't collect data you won't use to improve their results.
+**Ethical boundary:** Don't collect data you won't use to improve their results — every qualifying question (budget, urgency, size) must visibly shape the recommendation, not just route them to sales.
 
-See: [references/psychology.md](references/psychology.md) for the psychological foundations of question design and tension creation.
+See [references/psychology.md](references/psychology.md) when writing or critiquing questions — the tension taxonomy (pain/desire/frustration), the 4-6 quantification sweet spot, and the personalization stats.
 
 ### 3. Results Page
 
@@ -108,9 +108,9 @@ See: [references/psychology.md](references/psychology.md) for the psychological 
 - Low tier: "This area needs attention. Here are easy first steps... Our team specializes in helping people at your stage."
 - High tier: "Excellent foundation! Focus on maintaining standards. We work with advanced clients like yourself on [specific advanced offer]."
 
-**Ethical boundary:** Results must deliver genuine insight, not manufactured anxiety — give low scorers actionable help, and never inflate or deflate scores to push an offer.
+**Ethical boundary:** Never inflate or deflate the computed score to steer a prospect toward the offer — the tier must reflect their actual answers.
 
-See: [references/technical-implementation.md](references/technical-implementation.md) for scoring logic, conditional content, PDF generation, and platform integration.
+See [references/technical-implementation.md](references/technical-implementation.md) when building the actual tool — scoring/weighting logic, conditional content rules, PDF generation, and platform comparison.
 
 ### 4. Sales and Marketing
 
@@ -137,9 +137,9 @@ See: [references/technical-implementation.md](references/technical-implementatio
 - Results email: "Your [Topic] Score is ready. Here's what we recommend based on your results."
 - Nurture: "Last week you scored [X] on [category]. Here are 3 ways to improve that score this month."
 
-**Ethical boundary:** Follow-up must respect consent and provide genuine value — never use assessment data to pressure, honor unsubscribes immediately, and never share individual data without permission.
+**Ethical boundary:** Never weaponize self-reported pain points to pressure a prospect — the data they volunteered is for tailoring help, not for manufacturing urgency.
 
-See: [references/analytics-optimization.md](references/analytics-optimization.md) for key metrics, A/B testing, funnel analysis, CRM integration, and lead scoring.
+See [references/analytics-optimization.md](references/analytics-optimization.md) when a live funnel underperforms or you're setting up tracking — key metrics, what to A/B test, funnel-drop analysis, CRM integration, and lead scoring.
 
 ## Scorecard Naming Strategy
 
@@ -162,14 +162,14 @@ See: [references/analytics-optimization.md](references/analytics-optimization.md
 1. **Tension creation:** Questions surface dormant desires
 2. **Reciprocity:** You gave value (insights), they're open to conversation
 3. **Self-qualification:** They told you their problems and budget
-4. **Personalization:** 83% of consumers share data for a personalized experience
+4. **Personalization:** people willingly trade data for a tailored result, then expect the offer to match it (the supporting stats live in references/psychology.md)
 5. **Gamification:** Primal drive to score, rank, and improve
 6. **Commitment:** Time invested increases follow-through
 
 ## Implementation Checklist
 
 1. [ ] Define ideal customer and their desired outcome
-2. [ ] Choose concept hook (readiness/category/knowledge/pain removal)
+2. [ ] Choose a concept hook (one of the 5 types from the Landing Page section)
 3. [ ] Write 2-7 scoring categories based on your methodology
 4. [ ] Create 10-40 questions with point values
 5. [ ] Set up 3 scoring tiers with dynamic content
@@ -195,19 +195,12 @@ See: [references/analytics-optimization.md](references/analytics-optimization.md
 
 | Question | If No | Action |
 |----------|-------|--------|
-| Does the hook target a dormant desire? | Landing page underperforms | Rewrite using one of the 5 hook types (moving toward, pain removal, readiness, category, knowledge) |
+| Does the hook target a dormant desire? | Landing page underperforms | Rewrite using one of the 5 hook types (see Landing Page section) |
 | Is email captured before questions? | Losing all abandon leads | Move lead capture before the questionnaire |
 | Are questions grouped into scored categories? | Results feel arbitrary | Create 2-7 categories with point values |
 | Does each tier have unique dynamic content? | Generic results, no tension | Write personalized insights and CTAs per tier |
 | Is there a specific CTA per tier? | Prospects leave without converting | Map each tier to a next step (event, call, consultation) |
 | Are follow-up emails segmented by score? | Nurture feels irrelevant | Separate sequences per tier with tailored content |
-
-## Reference Files
-
-- [industry-examples.md](references/industry-examples.md): 50+ specific scorecard concepts across industries with hook templates
-- [psychology.md](references/psychology.md): Buyer psychology, tension creation, dormant desires, and why assessments convert
-- [technical-implementation.md](references/technical-implementation.md): Platform comparison, conditional logic, scoring patterns, PDF generation, integrations
-- [analytics-optimization.md](references/analytics-optimization.md): Key metrics, A/B testing elements, funnel analysis, CRM integration, lead scoring
 
 ## Further Reading
 

--- a/software-design-philosophy/SKILL.md
+++ b/software-design-philosophy/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: software-design-philosophy
-description: 'Manage software complexity through deep modules, information hiding, and strategic programming. Use when the user mentions "module design", "API too complex", "shallow class", "complexity budget", "strategic vs tactical", "deep module", "information leakage", "pass-through method", "this code is over-engineered", "too many layers", "the abstraction isnt worth it", or "simplify this design". Also trigger when reviewing an interface for simplicity, evaluating whether an abstraction is pulling its weight, or choosing between general-purpose and special-purpose approaches. Covers deep vs shallow modules, red flags for complexity, and comments as design documentation. For code quality, see clean-code. For boundaries, see clean-architecture.'
+description: 'Manage software complexity through deep modules, information hiding, and strategic programming. Use when the user mentions "module design", "API too complex", "shallow class", "complexity budget", "strategic vs tactical", "deep module", "information leakage", "pass-through method", "this code is over-engineered", or "simplify this design". Also trigger when reviewing an interface for simplicity, evaluating whether an abstraction is pulling its weight, deciding whether a comment is worth writing, or choosing between general-purpose and special-purpose approaches. Covers deep vs shallow modules, red flags for complexity, and comments as design documentation. For code quality, see clean-code. For architecture boundaries, see clean-architecture.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # A Philosophy of Software Design Framework
@@ -17,7 +17,14 @@ A practical framework for managing the fundamental challenge of software enginee
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing or creating software designs, rate them 0-10: a 10/10 means deep modules with clean abstractions, excellent information hiding, strategic thinking, and comments that capture design intent; lower scores indicate shallow modules, leakage, or tactical shortcuts. Always give the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** When reviewing or creating a design, score it by counting how many of the eight Quick Diagnostic rows it satisfies (≈1.25 points each), then sanity-check against the bands:
+
+- **9-10** — deep modules with interfaces far simpler than implementations; no information leakage (an implementation can change without touching callers); interface comments capture design intent; design improvement is routine. All eight diagnostics pass.
+- **6-8** — mostly deep, but one or two leaks, shallow classes, or undocumented abstractions. 5-6 diagnostics pass.
+- **3-5** — classitis or temporal decomposition, recurring leakage, comments that only restate code. 2-4 diagnostics pass.
+- **≤2** — tactical-tornado code: shallow modules, pervasive leakage, no design intent recorded. 0-1 diagnostics pass.
+
+Always state the current score, the diagnostic rows that failed, and the specific change each one needs to reach 10/10.
 
 ## The Software Design Framework
 
@@ -26,8 +33,6 @@ Six principles for managing complexity and producing systems that are easy to un
 ### 1. Complexity and Its Causes
 
 **Core concept:** Complexity is anything about a system's structure that makes it hard to understand and modify. It shows three symptoms — change amplification, cognitive load, and unknown unknowns — and has two causes: dependencies and obscurity.
-
-**Why it works:** Naming the specific symptoms lets developers diagnose problems precisely instead of relying on vague notions of "messy code," and the two causes provide clear targets for improvement.
 
 **Key insights:**
 - Change amplification: a simple change requires edits in many places
@@ -44,13 +49,13 @@ Six principles for managing complexity and producing systems that are easy to un
 | Unknown unknowns | Make dependencies explicit | Type systems and interfaces surface what a change affects |
 | Obscurity | Name things precisely | `numBytesReceived` not `n`; `retryDelayMs` not `delay` |
 
-See: [references/complexity-symptoms.md](references/complexity-symptoms.md) for symptom diagnosis and how complexity accumulates.
+See [references/complexity-symptoms.md](references/complexity-symptoms.md) when you need to name *which* symptom a codebase has before fixing it — per-symptom recognition tests, the dependency taxonomy (syntactic/semantic/temporal/hidden), the C = Σ(cp·tp) cost formula, and a 10-row red-flag table.
 
 ### 2. Deep vs Shallow Modules
 
 **Core concept:** The best modules are deep: powerful functionality behind a simple interface. Shallow modules have complex interfaces relative to the functionality they provide — they add complexity rather than hiding it.
 
-**Why it works:** The interface is the complexity a module imposes on the rest of the system; the implementation is the functionality it provides. Deep modules maximize benefit per unit of interface cost.
+**Why it works:** The interface is the *cost* a module imposes on the rest of the system; the implementation is the benefit. So a method that is harder to learn than to re-implement yourself is net-negative — depth, not line count, decides whether a module earns its place.
 
 **Key insights:**
 - Depth = functionality provided / interface complexity imposed (Unix file I/O is deep; thin Java I/O wrappers are shallow)
@@ -66,13 +71,13 @@ See: [references/complexity-symptoms.md](references/complexity-symptoms.md) for 
 | Classitis cure | Merge related shallow classes | `RequestParser` + `RequestValidator` + `RequestProcessor` → one `RequestHandler` |
 | Interface simplicity | Fewer parameters, fewer methods | `config.get(key)` with sensible defaults, not 15 constructor parameters |
 
-See: [references/deep-modules.md](references/deep-modules.md) when judging whether an abstraction pulls its weight.
+See [references/deep-modules.md](references/deep-modules.md) when judging whether an abstraction pulls its weight — before/after code for the depth ratio, the classitis cure worked out, and case studies (Unix I/O, GC, TCP/IP).
 
 ### 3. Information Hiding and Leakage
 
 **Core concept:** Each module should encapsulate knowledge not needed by other modules. Information leakage — one design decision reflected in multiple modules — is one of the most important red flags in software design.
 
-**Why it works:** Hidden knowledge can change inside one module; leaked knowledge makes changes propagate through the system. Hiding attacks both causes of complexity: dependencies and obscurity.
+**Why it works:** A decision that lives in one module can change there and nowhere else; the same decision leaked into N modules turns one edit into N edits that no compiler will remind you to make. Hiding is what converts change amplification back into a local change.
 
 **Key insights:**
 - Temporal decomposition causes leakage: splitting code by *when* things happen forces shared knowledge across phases — organize by knowledge instead
@@ -88,13 +93,13 @@ See: [references/deep-modules.md](references/deep-modules.md) when judging wheth
 | Temporal decomposition | Organize by knowledge, not time | Combine "read config" and "apply config" into one config module |
 | Protocol leakage | Abstract transport details | `MessageBus.send(event)` hides HTTP vs. gRPC vs. queue |
 
-See: [references/information-hiding.md](references/information-hiding.md) for leakage red flags and decorator pitfalls.
+See [references/information-hiding.md](references/information-hiding.md) when a change forces you to edit two modules in lockstep — the four leakage forms with code (interface, back-door, temporal, decorator), five reduction strategies, the HTTP-handling case study, and a detection table.
 
 ### 4. General-Purpose vs Special-Purpose Modules
 
 **Core concept:** Design modules that are "somewhat general-purpose": an interface general enough to support multiple uses, with an implementation that handles current needs. Ask: "What is the simplest interface that will cover all my current needs?"
 
-**Why it works:** General-purpose interfaces are usually simpler because they eliminate special cases, and new use cases often fit the existing abstraction — while over-generalization wastes effort on speculative complexity.
+**Why it works:** Counterintuitively, the general interface is usually the *simpler* one — special-case methods multiply as requirements grow, while one general method absorbs them. The trap is the other direction: generality the current needs don't demand is speculative complexity, paid now for a use case that may never arrive.
 
 **Key insights:**
 - "Somewhat general-purpose" is the sweet spot between too specific and too generic
@@ -110,13 +115,13 @@ See: [references/information-hiding.md](references/information-hiding.md) for le
 | Reduce configuration | Determine behavior automatically | Auto-detect file encoding instead of an `encoding` parameter |
 | Avoid over-specialization | One general method over many specific ones | `store(key, value, options)` instead of `storeUser()`, `storeProduct()`, `storeOrder()` |
 
-See: [references/general-vs-special.md](references/general-vs-special.md) when choosing how general an interface should be.
+See [references/general-vs-special.md](references/general-vs-special.md) when choosing how general an interface should be — the "simplest interface for all current needs" test, the configuration-parameter antipattern, and push-complexity-downward worked through.
 
 ### 5. Comments as Design Documentation
 
 **Core concept:** Comments should describe what is not obvious from the code: design intent, abstraction rationale, invariants, and assumptions. "Good code is self-documenting" is a myth for anything beyond low-level implementation detail.
 
-**Why it works:** Code tells you what the program does, not why, what the alternatives were, or what it assumes — comments capture the designer's mental model, the most valuable and most perishable information in a system.
+**Why it works:** Code can only ever record *what* it does — never why this approach over the alternatives, or what it silently assumes. That rationale is the most perishable information in a system: it lives only in the author's head and is gone the moment they move on, so a comment is the single chance to capture it.
 
 **Key insights:**
 - Four types: interface comments (most important — they define the abstraction), data structure member comments, implementation comments, cross-module comments
@@ -133,7 +138,7 @@ See: [references/general-vs-special.md](references/general-vs-special.md) when c
 | Implementation comment | Explain why, not what | "// Binary search: list is always sorted, can hold 100k+ items" |
 | Cross-module comment | Link related decisions | "// This timeout must match the retry interval in RetryPolicy.java" |
 
-See: [references/comments-as-design.md](references/comments-as-design.md) for comment-driven design and the self-documenting-code myth.
+See [references/comments-as-design.md](references/comments-as-design.md) when writing or reviewing comments and unsure what belongs in one — the four comment types with examples, the comment-driven-design procedure, and the rebuttal to the self-documenting-code myth.
 
 ### 6. Strategic vs Tactical Programming
 
@@ -155,7 +160,7 @@ See: [references/comments-as-design.md](references/comments-as-design.md) for co
 | Strategic investment | Improve structure during feature work | Refactor an awkward module interface while adding the feature |
 | Design reviews | Evaluate structure, not just correctness | Ask "does this make the system simpler?" not just "does it work?" |
 
-See: [references/strategic-programming.md](references/strategic-programming.md) for the investment mindset and startup considerations.
+See [references/strategic-programming.md](references/strategic-programming.md) when deciding how much design effort a change deserves, or making the case for it — the 10-20% investment math, the tactical-tornado pattern, and why startups need strategic programming most.
 
 ## Common Mistakes
 
@@ -165,9 +170,9 @@ See: [references/strategic-programming.md](references/strategic-programming.md) 
 | **Splitting modules by temporal order** | "Read, then process, then write" forces shared knowledge across modules | Group code that shares knowledge into one module |
 | **Exposing implementation in interfaces** | Callers depend on internals; changes propagate | Design interfaces around abstractions; hide formats and protocols |
 | **Treating comments as optional** | Design intent and assumptions are lost; newcomers guess wrong | Write interface comments first; maintain with the code |
-| **Configuration parameters for everything** | Each parameter pushes a decision onto the caller | Determine behavior automatically; provide sensible defaults |
+| **Configuration parameters for everything** | A parameter offloaded to the caller is a decision you declined to make (see §4) | Determine behavior automatically; provide sensible defaults |
 | **Quick-and-dirty tactical fixes** | Shortcuts compound until the system is unworkable | Invest 10-20% extra; treat every change as a design opportunity |
-| **Pass-through methods** | Delegation-only methods add interface without depth | Merge the pass-through into the caller or the callee |
+| **Pass-through methods** | A method that only forwards its arguments to another adds an interface but no functionality | Merge the pass-through into the caller or the callee |
 | **Designing for specific use cases** | Special-purpose interfaces accumulate special cases | Ask: simplest interface covering all current needs? |
 
 ## Quick Diagnostic
@@ -182,15 +187,6 @@ See: [references/strategic-programming.md](references/strategic-programming.md) 
 | Does each module hide an important design decision? | Modules organized around code, not information | Reorganize so each module owns specific knowledge |
 | Can a newcomer understand module boundaries without reading implementations? | Abstractions undocumented or leaky | Improve interface comments; simplify interfaces |
 | Are you spending 10-20% of time on design improvement? | Debt accumulates with every feature | Include design improvement in every PR |
-
-## Reference Files
-
-- [complexity-symptoms.md](references/complexity-symptoms.md): Three symptoms of complexity, two causes, measuring complexity, its incremental nature
-- [deep-modules.md](references/deep-modules.md): Deep vs shallow modules, interface-to-functionality ratio, classitis, designing for depth
-- [information-hiding.md](references/information-hiding.md): Information hiding principle, leakage red flags, temporal decomposition, decorator pitfalls
-- [general-vs-special.md](references/general-vs-special.md): Somewhat general-purpose approach, pushing complexity down, configuration parameter antipattern
-- [comments-as-design.md](references/comments-as-design.md): Four comment types, comment-driven design, self-documenting code myth, maintaining comments
-- [strategic-programming.md](references/strategic-programming.md): Strategic vs tactical mindset, tactical tornado, investment approach, startup considerations
 
 ## Further Reading
 

--- a/steve-jobs-design-review/SKILL.md
+++ b/steve-jobs-design-review/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: steve-jobs-design-review
-description: 'Review designs, products, and features with Steve Jobs'' standards: ruthless simplicity, focus, and end-to-end excellence. Use when the user mentions "Steve Jobs review", "design review", "product review", "what would Steve do", "insanely great", "simplify this product", "too many features", "product taste", "saying no", "is this good enough to ship", "make it simpler", or "this feels too complicated". Also trigger when critiquing a UI, feature, or roadmap for focus and simplicity, cutting scope to the essential, or pressure-testing the whole experience from first run to daily use. Covers the simplicity audit, the no list, design-is-how-it-works, end-to-end ownership, demo culture, and a Jobs-style review protocol with binary verdicts. For visual design fundamentals, see refactoring-ui. For usability audits, see ux-heuristics. For detail polish, see microinteractions.'
+description: 'Review designs, products, and features with Steve Jobs'' standards: ruthless simplicity, focus, and end-to-end excellence. Use when the user mentions "Steve Jobs review", "design review", "product review", "what would Steve do", "insanely great", "this feels too complicated", "too many features", "product taste", "saying no", or "is this good enough to ship". Also trigger when critiquing a UI, feature, or roadmap for focus and simplicity, cutting scope to the essential, or pressure-testing the whole experience from first run to daily use. Covers the simplicity audit, the no list, design-is-how-it-works, end-to-end ownership, demo culture, and a Jobs-style review protocol with binary verdicts. For visual design fundamentals, see refactoring-ui. For usability audits, see ux-heuristics. For detail polish, see microinteractions.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Steve Jobs Design Review
@@ -17,7 +17,7 @@ Run design and product reviews the way Steve Jobs ran them: start from the custo
 
 ## Scoring
 
-**Goal: 10/10.** When reviewing a design, product, feature, or roadmap, rate it 0-10 against the principles below. State the current score, exactly what fails, and the specific cuts or fixes required to reach 10/10. There is no "pretty good" — anything below 10 is not done yet.
+**Goal: 10/10.** Count how many of the 7 Quick Diagnostic rows the product passes, then map to 0-10: 7/7 = 10, 6/7 = 9, 5/7 = 7, 4/7 = 6, 3/7 = 4, ≤2/7 ≤ 3. Bands: **9-10** = insanely great, ships; **5-8** = real cuts and fixes required; **≤4** = not done, back to demos. There is no "pretty good"; state the score, the exact rows that failed, and the specific cuts or fixes required to reach 10/10.
 
 ## Framework
 
@@ -49,7 +49,7 @@ Run design and product reviews the way Steve Jobs ran them: start from the custo
 
 **Ethical boundary:** Simplify by solving complexity for the user, never by burying necessary controls or costs (pricing, privacy, cancellation) where they can't be found.
 
-See: [references/simplicity-and-focus.md](references/simplicity-and-focus.md)
+See [references/simplicity-and-focus.md](references/simplicity-and-focus.md) when running a simplicity audit — the 5-step subtraction method, steps-to-value measurement, and the surface-vs-deep simplicity table.
 
 ### 2. Focus Means Saying No
 
@@ -79,7 +79,7 @@ See: [references/simplicity-and-focus.md](references/simplicity-and-focus.md)
 
 **Ethical boundary:** Say no to scope, never to evidence — killing a feature is strategy; ignoring user pain that contradicts your vision is vanity.
 
-See: [references/review-protocol.md](references/review-protocol.md)
+See [references/review-protocol.md](references/review-protocol.md) for the saying-no rituals — the force-rank-to-three exercise, the kill-for-every-add rule, and how to run a no list in a live review.
 
 ### 3. Design Is How It Works
 
@@ -107,9 +107,7 @@ See: [references/review-protocol.md](references/review-protocol.md)
 - "How does this feel after the 100th use, not the demo?"
 - "Where does the user wait, and what did we do about it?"
 
-**Ethical boundary:** "How it works" includes how it respects the user — dark patterns that work for the business but against the user fail this review by definition.
-
-See: [references/end-to-end-experience.md](references/end-to-end-experience.md)
+See [references/end-to-end-experience.md](references/end-to-end-experience.md) when reviewing behavior over visuals — the daily-use and failure/support stages cover how to walk the slow moments, error paths, and offline states most demos skip.
 
 ### 4. Own the Whole Experience
 
@@ -139,7 +137,7 @@ See: [references/end-to-end-experience.md](references/end-to-end-experience.md)
 
 **Ethical boundary:** Owning the whole experience means owning failures too — never design a polished entrance and a hostile exit.
 
-See: [references/end-to-end-experience.md](references/end-to-end-experience.md)
+See [references/end-to-end-experience.md](references/end-to-end-experience.md) when mapping the journey — the 7-stage touchpoint map from discovery to offboarding, the worst-touchpoint rule, and the org seams that produce undesigned surfaces.
 
 ### 5. Demo or It Doesn't Exist
 
@@ -169,7 +167,7 @@ See: [references/end-to-end-experience.md](references/end-to-end-experience.md)
 
 **Ethical boundary:** Demos must show honest state — a staged demo that hides known breakage is a lie with a UI.
 
-See: [references/demo-culture.md](references/demo-culture.md)
+See [references/demo-culture.md](references/demo-culture.md) when setting up a demo-driven review — the creative-selection loop, how to run a demo derby, the decider role, and honest-demo rules.
 
 ### 6. Taste and the Back of the Fence
 
@@ -197,9 +195,7 @@ See: [references/demo-culture.md](references/demo-culture.md)
 - "Would you sign your name inside this?"
 - "Where did we use plywood?"
 
-**Ethical boundary:** High standards apply to the work, never to a person's worth — demand excellence without demeaning people.
-
-See: [references/case-studies.md](references/case-studies.md)
+See [references/case-studies.md](references/case-studies.md) for worked examples of the standard in action — the original Mac circuit board redone for unseen beauty, the iMac's opinionated subtraction, plus the MobileMe and antenna-gate failure reviews and what each teaches a reviewer.
 
 ### 7. Running the Review
 
@@ -226,9 +222,7 @@ ALWAYS output reviews in this format:
 **Back of the fence:** [unseen surfaces that fail the bar]
 ```
 
-**Ethical boundary:** Channel Jobs' standards, not his cruelty — total candor about the work, zero contempt for the people who made it.
-
-See: [references/review-protocol.md](references/review-protocol.md)
+See [references/review-protocol.md](references/review-protocol.md) when running an actual review session — the timed 5-step agenda, the fix-item specificity test, the candor rules (brutal on work, decent on people), review cadence, and how to adapt the protocol for solo or async reviews.
 
 ## Common Mistakes
 
@@ -253,14 +247,6 @@ See: [references/review-protocol.md](references/review-protocol.md)
 | Was anything removed this cycle? | Roadmap is accreting, not focusing | Add a cut list to every review |
 | Do error, empty, and edge states match hero-screen quality? | Back of the fence is plywood | Audit and fix unseen surfaces |
 | Would the team proudly use it daily and sign it? | The bar is "acceptable", not "insanely great" | Hold the binary verdict until pride is real |
-
-## Reference Files
-
-- [review-protocol.md](references/review-protocol.md): Full Jobs-style review session — agenda, walkthrough order, verdict format, saying-no rituals
-- [simplicity-and-focus.md](references/simplicity-and-focus.md): Simplicity audit method, steps-to-value, the 2×2 product matrix, the no list
-- [end-to-end-experience.md](references/end-to-end-experience.md): Whole-widget touchpoint audit from discovery to offboarding, first-run theater
-- [demo-culture.md](references/demo-culture.md): Creative selection loop, demo derbies, decider roles, honest-demo rules
-- [case-studies.md](references/case-studies.md): iMac, iPod, iPhone keyboard, Apple Stores, MobileMe failure review — what each teaches reviewers
 
 ## About the Author
 

--- a/storybrand-messaging/SKILL.md
+++ b/storybrand-messaging/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: storybrand-messaging
-description: 'Clarify brand messaging using narrative structure that positions the customer as hero. Use when the user mentions "brand message", "website copy", "elevator pitch", "one-liner", "messaging isnt resonating", "brand script", "StoryBrand framework", "customer as hero", "rewrite my homepage", "clarify my message", or "my website copy is confusing". Also trigger when rewriting homepage copy, crafting email nurture sequences, or creating consistent messaging across sales and marketing collateral. Covers landing page copy, marketing collateral, and consistent communication. For memorable messaging, see made-to-stick. For product positioning, see obviously-awesome.'
+description: 'Clarify brand messaging using narrative structure that positions the customer as hero. Use when the user mentions "brand message", "website copy", "elevator pitch", "one-liner", "brand script", "StoryBrand framework", "customer as hero", or "my messaging isnt resonating". Also trigger when rewriting homepage copy, crafting email nurture sequences, or creating consistent messaging across sales and marketing collateral. Covers landing page copy, marketing collateral, and consistent communication. For memorable messaging, see made-to-stick. For product positioning, see obviously-awesome.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # StoryBrand Messaging Framework
@@ -17,7 +17,7 @@ Clarify your message so customers will listen. Customers don't buy the best prod
 
 ## Scoring
 
-**Goal: 10/10.** Rate any marketing copy or brand messaging 0-10 against the principles below. Always state the current score and the specific changes needed to reach 10/10.
+**Goal: 10/10.** Score any marketing copy or brand messaging by the Quick Diagnostic: 1 point per satisfied row (7 rows) plus up to 3 points for a one-liner that passes the cocktail party test (clear + repeatable in one hearing). Bands: 9-10 = customer is the hero, all three problem levels named, empathy + authority both shown, a 3-step plan, one obvious Direct CTA, and both success and failure stakes painted; 5-6 = SB7 partly applied but the internal problem, stakes, or CTA is missing; <=3 = brand-as-hero, feature-led, or no clear ask. Always state the current score and the specific changes needed to reach 10/10.
 
 ## The SB7 Framework
 
@@ -48,9 +48,7 @@ Every compelling story follows the same pattern. Use this structure for all mess
 - "Imagine [aspirational identity]..."
 - "What if you could [single clear outcome]?"
 
-**Ethical boundary:** Ground desires in real research or observed behavior — never fabricate aspirations the customer does not hold.
-
-See: [references/brand-script.md](references/brand-script.md) for the complete BrandScript worksheet covering all seven elements.
+See: [references/brand-script.md](references/brand-script.md) — fill out the BrandScript worksheet here when you need to draft all seven elements for a client from scratch.
 
 ### 2. Has a Problem
 
@@ -76,8 +74,6 @@ See: [references/brand-script.md](references/brand-script.md) for the complete B
 - "[Villain] has been keeping you from [desire]..."
 - "It's not right that [philosophical problem]..."
 
-**Ethical boundary:** Name real frustrations honestly — never exaggerate problems or invent suffering to create fear.
-
 ### 3. And Meets a Guide
 
 **Core concept:** Your brand is the guide, expressing empathy AND authority. Empathy shows you understand the pain; authority proves you can solve it.
@@ -85,7 +81,6 @@ See: [references/brand-script.md](references/brand-script.md) for the complete B
 **Why it works:** Customers are looking for a guide, not another hero — think Yoda, not Luke. Empathy makes them feel seen, authority (testimonials, logos, statistics) makes them feel safe, and together they create trust.
 
 **Key insights:**
-- Empathy without authority seems weak; authority without empathy seems arrogant
 - Show empathy with "we understand" language; show authority with testimonials, client logos, statistics, awards
 - Never make your origin story the centerpiece — that is hero behavior; brief, relevant credentials suffice
 
@@ -102,9 +97,7 @@ See: [references/brand-script.md](references/brand-script.md) for the complete B
 - "We've helped [number] [customers] achieve [result]..."
 - "You don't have to figure this out alone..."
 
-**Ethical boundary:** Claim only earned authority — real testimonials, accurate statistics, verifiable credentials.
-
-See: [references/sales-conversations.md](references/sales-conversations.md) for discovery questions, objection handling, and sales scripts.
+See: [references/sales-conversations.md](references/sales-conversations.md) — open when scripting a sales call or discovery session; covers discovery questions, objection handling, and full SB7 sales scripts.
 
 ### 4. Who Gives Them a Plan
 
@@ -130,8 +123,6 @@ See: [references/sales-conversations.md](references/sales-conversations.md) for 
 - "Getting started is easy. Just [step 1]."
 - "We promise [agreement plan commitment]."
 
-**Ethical boundary:** Promise only outcomes you reliably deliver, and honor agreement-plan commitments without exception.
-
 ### 5. And Calls Them to Action
 
 **Core concept:** If you don't ask, they won't act. Use a Direct CTA (primary conversion action) plus a Transitional CTA (lower-commitment alternative).
@@ -156,9 +147,9 @@ See: [references/sales-conversations.md](references/sales-conversations.md) for 
 - "Start your free [trial/demo/assessment] today."
 - "Download your free [lead magnet]."
 
-**Ethical boundary:** CTAs must honestly represent what happens on click — never disguise a purchase as a free action.
+**Ethical boundary:** Never label a paid action as "free" or a Transitional CTA — the button text must match what happens on click.
 
-See: [references/website-wireframe.md](references/website-wireframe.md) for page-by-page structure and interior page templates.
+See: [references/website-wireframe.md](references/website-wireframe.md) — open when laying out a homepage or site; gives section-by-section structure and interior page templates.
 
 ### 6. That Helps Them Avoid Failure
 
@@ -184,8 +175,6 @@ See: [references/website-wireframe.md](references/website-wireframe.md) for page
 - "How long will you wait before [addressing the problem]?"
 - "Every day without [solution], you're [cost of inaction]."
 
-**Ethical boundary:** State real, proportionate consequences of inaction — no fear-mongering or fabricated urgency.
-
 ### 7. And Ends in Success
 
 **Core concept:** Paint a vivid picture of life after working with you — in terms of status, completeness, and self-realization. Success closes the story gap opened in Element 1.
@@ -210,8 +199,6 @@ See: [references/website-wireframe.md](references/website-wireframe.md) for page
 - "Join [number] [customers] who now [success outcome]..."
 - "Finally, [completeness outcome] — without [old frustration]."
 
-**Ethical boundary:** Promise only substantiated results; testimonials must reflect genuine customer experiences.
-
 ## The One-Liner
 
 A single sentence that explains what you do. Use it everywhere.
@@ -222,9 +209,9 @@ A single sentence that explains what you do. Use it everywhere.
 
 **Example:** "We help small business owners who feel overwhelmed by marketing create a clear message so they can grow their revenue."
 
-**Test:** Can someone repeat it after hearing it once?
+**Test:** Can someone repeat it after hearing it once? (the cocktail party test)
 
-See: [references/one-liners.md](references/one-liners.md) for industry examples and variations.
+See: [references/one-liners.md](references/one-liners.md) — open when drafting a one-liner; ~20 industry examples plus three alternative formulas (PSR, BAB, "We Exist Because").
 
 ## Tone and Voice Guidelines
 
@@ -234,7 +221,8 @@ Keep brand voice consistent across channels while adapting to context.
 
 **Avoid:** hero language ("We're the best at..."), jargon (use the customer's words), condescension, and tentative weakness.
 
-See: [references/multi-channel-consistency.md](references/multi-channel-consistency.md) for social media, video, podcast, and PR adaptation.
+See: [references/email-sequences.md](references/email-sequences.md) — open when building a nurture or welcome sequence; SB7-mapped templates and subject-line formulas.
+See: [references/multi-channel-consistency.md](references/multi-channel-consistency.md) — open when adapting the message to a channel; social, video, podcast, and PR playbooks.
 
 ## Common Mistakes
 
@@ -259,15 +247,6 @@ See: [references/multi-channel-consistency.md](references/multi-channel-consiste
 | Is there a clear 3-step plan? | Path feels risky | Add Process + Agreement plans |
 | Is there one obvious CTA? | Nobody acts | Add prominent, repeated Direct CTA |
 | Do you show success AND failure stakes? | No narrative tension | Paint both outcome pictures |
-
-## Reference Files
-
-- [brand-script.md](references/brand-script.md): Complete BrandScript worksheet for all seven elements
-- [one-liners.md](references/one-liners.md): One-liner formula, industry examples, variations
-- [website-wireframe.md](references/website-wireframe.md): Page-by-page website structure, interior page templates
-- [email-sequences.md](references/email-sequences.md): Nurture and welcome sequences, templates, subject line formulas
-- [sales-conversations.md](references/sales-conversations.md): Discovery questions, objection handling, sales scripts
-- [multi-channel-consistency.md](references/multi-channel-consistency.md): Social media adaptation, video scripts, podcast, PR, brand voice guidelines
 
 ## Further Reading
 

--- a/system-design/SKILL.md
+++ b/system-design/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: system-design
-description: 'Design scalable distributed systems using structured approaches for load balancing, caching, database scaling, and message queues. Use when the user mentions "system design", "scale this", "high availability", "rate limiter", "design a URL shortener", "design Twitter", "design Uber", "design a news feed", "system design interview", "system design interview prep", "capacity planning", or "distributed architecture". Also trigger when estimating infrastructure requirements, choosing between microservices and monoliths, or designing for millions of concurrent users. Covers common system designs (TinyURL, feeds, chat) and back-of-the-envelope estimation. For data fundamentals, see ddia-systems. For resilience, see release-it.'
+description: 'Design scalable distributed systems using structured approaches for load balancing, caching, database scaling, and message queues. Use when the user mentions "system design", "scale this", "high availability", "rate limiter", "design a URL shortener", "design Twitter", "design Uber", "design a news feed", "system design interview", "capacity planning", or "distributed architecture". Also trigger when estimating infrastructure requirements, choosing between microservices and monoliths, or designing for millions of concurrent users. Covers common system designs (TinyURL, feeds, chat) and back-of-the-envelope estimation. For data fundamentals, see ddia-systems. For resilience, see release-it.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # System Design Framework
@@ -17,7 +17,7 @@ A structured approach to designing large-scale distributed systems. Apply these 
 
 ## Scoring
 
-**Goal: 10/10.** Rate any system design 0-10: a 10/10 states requirements explicitly, includes back-of-the-envelope estimates, uses appropriate building blocks, addresses scaling and reliability, and acknowledges tradeoffs. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score a design by counting how many of the eight Quick Diagnostic rows it satisfies (1 point each): 9-10 = all/nearly all rows pass — explicit requirements, real estimates, redundancy, a stated DB-scaling and caching strategy, async via queues, monitoring, and a deployment plan, with tradeoffs named; 5-6 = the design works but skips estimation, redundancy, or operations; <=3 = architecture proposed before requirements or estimates exist. Always state the current score, name the failing diagnostic rows, and give the specific fix for each.
 
 ## The System Design Framework
 
@@ -44,7 +44,7 @@ Six areas for building reliable, scalable distributed systems:
 | **Architecture review** | Walk reviewers through the steps sequentially | Scope, diagram, deep-dive on riskiest component, open questions |
 | **Incident postmortem** | Trace the failure through the four-step lens | Which requirement was missed? Which block failed? What tradeoff bit us? |
 
-See: [references/four-step-process.md](references/four-step-process.md)
+See [references/four-step-process.md](references/four-step-process.md) when running a design end-to-end — per-stage time allocation, example clarifying questions, and tips for each of the four steps.
 
 ### 2. Back-of-the-Envelope Estimation
 
@@ -68,13 +68,13 @@ See: [references/four-step-process.md](references/four-step-process.md)
 | **Storage budgeting** | Per-record size x volume x retention | 500M tweets/day x 300 bytes x 365 days = ~55 TB/year |
 | **SLA definition** | Convert nines to allowed downtime | Four nines = ~52 minutes downtime per year |
 
-See: [references/estimation-numbers.md](references/estimation-numbers.md)
+See [references/estimation-numbers.md](references/estimation-numbers.md) when sizing a system — full latency table, availability-nines table, and worked QPS/storage/bandwidth calculations.
 
 ### 3. Building Blocks
 
 **Core concept:** Scalable systems are assembled from a standard toolkit: DNS, CDN, load balancers, reverse proxies, application servers, caches, message queues, and consistent hashing.
 
-**Why it works:** Each block solves a specific scaling or reliability problem. Knowing when and why to introduce each prevents both premature complexity and avoidable bottlenecks.
+**Why it works:** Each block trades one cost for another (a cache trades freshness for read speed; a queue trades latency for decoupling), so introduce a block only once its specific bottleneck appears — adding all of them up front just multiplies failure modes.
 
 **Key insights:**
 - Load balancers: L4 (transport layer — fast, simple) vs L7 (application layer — content-aware routing)
@@ -92,7 +92,7 @@ See: [references/estimation-numbers.md](references/estimation-numbers.md)
 | **Global users** | CDN for static assets | Serve JS/CSS/images from edge; origin serves only API |
 | **Uneven load** | Consistent hashing for shard assignment | Adding a node moves only ~1/n keys |
 
-See: [references/building-blocks.md](references/building-blocks.md)
+See [references/building-blocks.md](references/building-blocks.md) when choosing components — how each of DNS, CDN, load balancers, caching strategies, message queues, and consistent hashing works and when to introduce it.
 
 ### 4. Database Design and Scaling
 
@@ -116,7 +116,7 @@ See: [references/building-blocks.md](references/building-blocks.md)
 | **User data at scale** | Hash-based sharding on user_id | hash(user_id) % num_shards; even, independent shards |
 | **Analytics dashboard** | Denormalized materialized views | Pre-join and aggregate nightly; serve from materialized table |
 
-See: [references/database-scaling.md](references/database-scaling.md)
+See [references/database-scaling.md](references/database-scaling.md) when the database is the bottleneck — replication topologies, the three sharding strategies compared, denormalization tradeoffs, and a SQL-vs-NoSQL selection guide.
 
 ### 5. Common System Designs
 
@@ -141,7 +141,7 @@ See: [references/database-scaling.md](references/database-scaling.md)
 | **API protection** | Token bucket at gateway | 100 tokens/min per key; steady refill; reject with 429 |
 | **Social feed** | Hybrid fanout | Precompute feeds for <10K-follower accounts; merge celebrity posts at read time |
 
-See: [references/common-designs.md](references/common-designs.md)
+See [references/common-designs.md](references/common-designs.md) when a problem resembles a known design — full walkthroughs of URL shortener, rate limiter, news feed, chat, autocomplete, web crawler, and unique ID generator.
 
 ### 6. Reliability and Operations
 
@@ -165,7 +165,7 @@ See: [references/common-designs.md](references/common-designs.md)
 | **Gradual rollout** | Canary with metric comparison | 5% traffic to new version; compare errors and latency; promote or rollback |
 | **Data safety** | Define RPO/RTO, implement accordingly | RPO 1 hour = hourly backups; RTO 5 min = automated failover |
 
-See: [references/reliability-operations.md](references/reliability-operations.md)
+See [references/reliability-operations.md](references/reliability-operations.md) when hardening for production — health-check patterns, the observability pillars, deployment strategies, disaster-recovery (RPO/RTO), and autoscaling.
 
 ## Common Mistakes
 
@@ -192,15 +192,6 @@ See: [references/reliability-operations.md](references/reliability-operations.md
 | Are async paths using queues? | Tight coupling, cascading failures | Decouple with Kafka/SQS for jobs, notifications, analytics |
 | Is there a monitoring and alerting plan? | Blind to production failures | Define metrics, log aggregation, tracing, alert thresholds |
 | Is the deployment strategy defined? | Risky all-at-once releases | Rolling, blue-green, or canary with automated rollback |
-
-## Reference Files
-
-- [four-step-process.md](references/four-step-process.md): The complete four-step process with time allocation, example questions, and tips per stage
-- [estimation-numbers.md](references/estimation-numbers.md): Powers of two, latency numbers, availability nines, QPS/storage/bandwidth worked examples
-- [building-blocks.md](references/building-blocks.md): DNS, CDN, load balancers, caching strategies, message queues, consistent hashing
-- [database-scaling.md](references/database-scaling.md): SQL vs NoSQL, replication, sharding strategies, denormalization, selection guide
-- [common-designs.md](references/common-designs.md): URL shortener, rate limiter, news feed, chat, autocomplete, web crawler, unique ID generator
-- [reliability-operations.md](references/reliability-operations.md): Health checks, monitoring, logging, deployment strategies, disaster recovery, autoscaling
 
 ## Further Reading
 

--- a/system-design/SKILL.md
+++ b/system-design/SKILL.md
@@ -4,7 +4,7 @@ description: 'Design scalable distributed systems using structured approaches fo
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # System Design Framework
@@ -17,7 +17,7 @@ A structured approach to designing large-scale distributed systems. Apply these 
 
 ## Scoring
 
-**Goal: 10/10.** Score a design by counting how many of the eight Quick Diagnostic rows it satisfies (1 point each): 9-10 = all/nearly all rows pass — explicit requirements, real estimates, redundancy, a stated DB-scaling and caching strategy, async via queues, monitoring, and a deployment plan, with tradeoffs named; 5-6 = the design works but skips estimation, redundancy, or operations; <=3 = architecture proposed before requirements or estimates exist. Always state the current score, name the failing diagnostic rows, and give the specific fix for each.
+**Goal: 10/10.** Score a design by how many of the eight Quick Diagnostic rows it satisfies — `score = round(passed / 8 × 10)`: 9-10 = all/nearly all rows pass — explicit requirements, real estimates, redundancy, a stated DB-scaling and caching strategy, async via queues, monitoring, and a deployment plan, with tradeoffs named; 5-6 = the design works but skips estimation, redundancy, or operations; <=3 = architecture proposed before requirements or estimates exist. Always state the current score, name the failing diagnostic rows, and give the specific fix for each.
 
 ## The System Design Framework
 

--- a/team-topologies/SKILL.md
+++ b/team-topologies/SKILL.md
@@ -193,14 +193,6 @@ See: [references/case-studies.md](references/case-studies.md)
 | Are enabling engagements time-boxed with exit criteria? | Permanent dependency replaces learning | Set end dates and capability-transfer goals up front |
 | Is there a recurring mechanism to sense and evolve the topology? | Design rots as system and market shift | Quarterly review of friction, wait times, and on-call signals |
 
-## Reference Files
-
-- [team-types.md](references/team-types.md): Each team type in depth — responsibilities, staffing, success metrics, failure modes, converting existing teams, and a "which type is this team really?" decision guide
-- [interaction-modes.md](references/interaction-modes.md): Mode-by-mode mechanics, team interaction contracts, time-boxing collaboration, designing X-as-a-Service interfaces, the facilitation playbook, and mode-evolution triggers
-- [cognitive-load.md](references/cognitive-load.md): Assessing team cognitive load (survey, domain counting, on-call and tooling proxies), the full team API template, domain-allocation heuristics, and overload warning signs
-- [fracture-planes.md](references/fracture-planes.md): The fracture-plane catalog with selection criteria, a monolith-to-team-ownership mapping exercise, DDD alignment, shared-code options, and sequencing an inverse Conway reorg
-- [case-studies.md](references/case-studies.md): Three scenarios — a scale-up redesigned into stream-aligned plus platform teams, an ops team converted to platform-as-product, and a monolith split with explicit interaction modes
-
 ## Further Reading
 
 - [*"Team Topologies: Organizing Business and Technology Teams for Fast Flow"*](https://www.amazon.com/Team-Topologies-Organizing-Business-Technology/dp/1942788819?tag=wondelai00-20) by Matthew Skelton & Manuel Pais

--- a/team-topologies/SKILL.md
+++ b/team-topologies/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: team-topologies
-description: 'Organize business and technology teams for fast flow using Skelton & Pais''s "Team Topologies". Use when the user mentions "team topologies", "Conway''s law", "platform team", "stream-aligned team", "team boundaries", "cognitive load", "how should we split teams", "org design", "who owns this service", "team dependencies", "reorg", or "teams keep stepping on each other". Also trigger when reorganizing engineering teams, aligning team and service boundaries, splitting a monolith and deciding ownership, reducing cross-team handoffs, or designing an internal platform. Covers the four team types, three interaction modes, the inverse Conway maneuver, and fracture planes. For bounded contexts, see domain-driven-design. For dependency direction in code, see clean-architecture.'
+description: 'Organize business and technology teams for fast flow using Skelton & Pais''s "Team Topologies". Use when the user mentions "team topologies", "Conway''s law", "platform team", "stream-aligned team", "team boundaries", "cognitive load", "how should we split teams", "who owns this service", "team dependencies", or "reorg". Also trigger when reorganizing engineering teams, aligning team and service boundaries, splitting a monolith and deciding ownership, reducing cross-team handoffs, or designing an internal platform. Covers the four team types, three interaction modes, the inverse Conway maneuver, and fracture planes. For bounded contexts, see domain-driven-design. For dependency direction in code, see clean-architecture.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Team Topologies
@@ -59,7 +59,7 @@ A team-first approach to organization design from Matthew Skelton and Manuel Pai
 - Stream-aligned is the default; the other three types are justified only by the load they remove from streams
 - An enabling team that never disengages has become a dependency — measure it by capabilities transferred, not tickets closed
 - Complicated-subsystem teams are justified by genuine specialism, never by managerial convenience — most orgs need zero or one
-- A platform is judged by cognitive load removed: if using it is harder than self-hosting, it is a liability with a roadmap
+- A platform exists to remove load from streams: if adopting it is harder than self-hosting, it is a liability, not a platform
 - Anti-patterns: shared-services teams become ticket-queue bottlenecks; a "DevOps team" between dev and ops adds a third silo; component teams everywhere mean every feature crosses many teams
 
 **Applications:**

--- a/top-design/SKILL.md
+++ b/top-design/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: top-design
-description: 'Create award-winning, immersive web experiences at the level of Awwwards-featured agencies. Use when the user mentions "premium website", "portfolio site", "scroll animations", "Awwwards quality", "brand experience", "cinematic web design", "parallax storytelling", "agency-quality site", "make my site stunning", "give it a wow factor", or "an impressive website". Also trigger when building a landing page that needs to impress, designing a creative portfolio, or elevating a standard website into a memorable digital experience. Covers dramatic typography, purposeful motion, scroll-based composition, and performance-optimized animation. For foundational UI, see refactoring-ui. For type selection, see web-typography.'
+description: 'Create award-winning, immersive web experiences at the level of Awwwards-featured agencies. Use when the user mentions "Awwwards quality", "make my site stunning", "scroll animations", "parallax storytelling", "cinematic web design", "portfolio site", or "brand experience". Also trigger when elevating a standard landing page into a memorable digital experience. Covers dramatic typography, purposeful motion, scroll-based composition, and performance-optimized animation. For foundational UI, see refactoring-ui. For type selection, see web-typography.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.5.0"
+  version: "1.6.0"
 ---
 
 # Top-Design: Award-Winning Digital Experiences
@@ -95,22 +95,9 @@ Total = (Typography x 0.25) + (Composition x 0.25) + (Motion x 0.20) + (Color x 
 - Optical alignment beats mathematical alignment -- adjust visually, not just numerically
 - Control every line break on headlines -- beautiful breaks require manual intervention at key breakpoints
 
-**Product applications:**
+**Applications:** viewport-filling display dropping hard to body (Locomotive hero); variable font with hover weight-animation (Studio Freight); serif/sans pairing at extreme scale contrast (AREA 17 editorial). Display = one statement, 3-7 words; body = 16-18px minimum, 45-75 character measure.
 
-| Context | Application | Example |
-|---------|-------------|---------|
-| Portfolio hero | Viewport-filling display type, dramatic drop to body | Locomotive.ca hero typography |
-| Brand website | Variable font with weight animation on hover | Studio Freight interactive type |
-| Editorial layout | Serif/sans pairing with extreme scale contrast | AREA 17 case studies |
-
-**Copy patterns:**
-- Display: single powerful statement, 3-7 words maximum
-- Subhead: one sentence that contextualizes the display type
-- Body: 16-18px minimum, generous line-height, 45-75 character measure
-
-**Ethical boundary:** Never sacrifice legibility for aesthetic novelty -- body text must meet WCAG contrast requirements and remain readable.
-
-See: [references/typography.md](references/typography.md) for font pairing strategies, type scale systems, and advanced CSS typography.
+See [references/typography.md](references/typography.md) when choosing typefaces or building the type scale -- named font pairings by style, full fluid `clamp()` and step-based scales, tracking/leading ladders, and font-subsetting/FOUT mechanics.
 
 ### 2. Layout & Composition
 
@@ -124,22 +111,11 @@ See: [references/typography.md](references/typography.md) for font pairing strat
 - Unexpected scale shifts create rhythm -- alternate massive/intimate, dense/sparse for narrative pacing
 - The grid paradox -- a strong underlying grid is what makes breaks meaningful; without it, breaks are chaos
 
-**Product applications:**
-
-| Context | Application | Example |
-|---------|-------------|---------|
-| Hero section | Offset title with bleeding imagery | `margin-left: 8.33%; margin-right: -5vw` |
-| Portfolio grid | Varied card sizes, intentional asymmetry | Locomotive project showcases |
-| Feature showcase | Overlapping elements creating depth | Active Theory layered compositions |
-
-**Copy patterns:**
-- Hero: position text off-center with intentional grid alignment
-- Sections: alternate full-width immersion with contained reading
-- Cards: vary sizes within grids -- uniformity is monotony
+**Applications:** offset title with bleeding imagery (`margin-left: 8.33%; margin-right: -5vw`); varied card sizes for intentional asymmetry (Locomotive showcases); overlapping elements for depth (Active Theory). Alternate full-width immersion with contained reading sections.
 
 **Ethical boundary:** Layout experimentation must never compromise navigation clarity -- users must always know where they are and how to move forward.
 
-See: [references/layout-systems.md](references/layout-systems.md) for grid frameworks, breakpoints, and responsive patterns.
+See [references/layout-systems.md](references/layout-systems.md) when laying out sections or going responsive -- grid frameworks, breakpoint systems, and asymmetric/bleeding-element patterns.
 
 ### 3. Motion & Animation
 
@@ -149,26 +125,15 @@ See: [references/layout-systems.md](references/layout-systems.md) for grid frame
 
 **Key insights:**
 - Custom easing is mandatory -- `ease`, `ease-in`, `ease-out`, `linear` are banned; use `cubic-bezier(0.16, 1, 0.3, 1)` (expo out), `cubic-bezier(0.25, 1, 0.5, 1)` (quart out), `cubic-bezier(0.87, 0, 0.13, 1)` (expo in-out)
-- Page load follows a strict choreography -- structure (0-200ms), hero title words staggered (200-600ms, 80ms stagger), subtitle (400-800ms), navigation cascade (600-900ms), supporting elements (800-1200ms)
+- Page load follows a strict choreography -- structure (0-200ms), hero title words staggered (200-600ms), subtitle (400-800ms), navigation cascade (600-900ms), supporting elements (800-1200ms); reference holds the canonical per-element stagger values
 - Animate in relationship, not isolation -- elements that move together feel cohesive and intentional
 - 60fps is non-negotiable -- if an animation drops frames, simplify or remove it
 
-**Product applications:**
-
-| Context | Application | Example |
-|---------|-------------|---------|
-| Page load | Choreographed staggered reveal sequence | Studio Freight entry animations |
-| Image reveals | Clip-path or mask animations on scroll enter | AREA 17 case study reveals |
-| Micro-interactions | Hover weight shifts, magnetic button effects | Dogstudio interactive details |
-
-**Copy patterns:**
-- Reveal: text lines slide up individually with stagger (never fade in as a block)
-- Hover: respond with scale shift or color transition
-- Transition: pages morph rather than cut or fade
+**Applications:** choreographed staggered page-load reveal (Studio Freight); clip-path/mask image reveals on scroll-enter (AREA 17); hover weight-shifts and magnetic buttons (Dogstudio). Text lines slide up individually with stagger -- never fade in as a block; pages morph rather than cut.
 
 **Ethical boundary:** Motion must never block interaction or cause motion sickness -- respect `prefers-reduced-motion`, keep all content accessible without animation, and justify anything longer than 1.2s.
 
-See: [references/animation-patterns.md](references/animation-patterns.md) for scroll animations, page transitions, and micro-interactions with code.
+See [references/animation-patterns.md](references/animation-patterns.md) when implementing motion -- copy-pasteable scroll reveals, staggered load choreography, page transitions, and magnetic/hover micro-interactions with code.
 
 ### 4. Color & Contrast
 
@@ -183,22 +148,9 @@ See: [references/animation-patterns.md](references/animation-patterns.md) for sc
 - Contextual color shifts between sections create visual chapters
 - Design the system for both light and dark contexts, not individual instances
 
-**Product applications:**
+**Applications:** monochromatic with signature accent (Locomotive: cream + black + orange spark); contextual shifting per case study (AREA 17); dark mode with one vibrant accent (Stripe: navy + purple). Drive everything from CSS custom properties (`--color-dark/-light/-accent` plus functional `--color-text-primary/-surface`); the accent appears only on CTAs, links, and single-detail moments.
 
-| Context | Application | Example |
-|---------|-------------|---------|
-| Agency portfolio | Monochromatic with signature accent | Locomotive: cream + black + orange spark |
-| Client showcase | Contextual shifting per case study | AREA 17: adapts palette to each client |
-| Product landing | Dark mode with single vibrant accent | Stripe: dark navy + signature purple |
-
-**Copy patterns:**
-- Define CSS custom properties: `--color-dark`, `--color-light`, `--color-accent`, then functional tokens (`--color-text-primary`, `--color-surface`)
-- Use opacity variants (`rgba(10, 10, 10, 0.6)`) for secondary/tertiary text
-- Accent appears on CTAs, links, and single-detail moments -- never everywhere
-
-**Ethical boundary:** All color combinations must meet WCAG 2.1 AA contrast minimums -- atmosphere cannot cost readability.
-
-See: [references/case-studies.md](references/case-studies.md) for agency technique breakdowns including color systems and micro-interactions.
+See [references/case-studies.md](references/case-studies.md) when you need a worked example of any pillar -- agency-by-agency breakdowns of real color systems, type treatments, and micro-interactions to reverse-engineer.
 
 ### 5. Scroll-Based Design
 
@@ -214,20 +166,11 @@ See: [references/case-studies.md](references/case-studies.md) for agency techniq
 - Reveals should be progressive -- elements enter as they become visible, creating discovery
 - Scroll velocity can modulate animation speed for a responsive feel
 
-**Product applications:**
-
-| Context | Application | Example |
-|---------|-------------|---------|
-| Product story | Pinned hero with scroll-driven transformation | Apple product deep-dives |
-| Landing page | Horizontal scroll gallery with affordance | Studio Freight work galleries |
-| Brand narrative | Scroll-driven animation sequences | Active Theory immersive stories |
-
-**Copy patterns:**
-- Use `data-scroll`, `data-scroll-speed`, `data-scroll-direction` for declarative behavior
-- Intersection observers for lightweight class toggling; GSAP ScrollTrigger only for complex multi-step sequences
-- Always provide a non-scroll fallback for accessibility
+**Applications:** pinned hero with scroll-driven transformation (Apple deep-dives); horizontal scroll gallery with affordance (Studio Freight); scroll-driven animation sequences (Active Theory). Use IntersectionObserver for lightweight class toggling; reserve GSAP ScrollTrigger for complex multi-step sequences.
 
 **Ethical boundary:** Scroll hijacking is hostile UX -- users must always be able to scroll at their own pace and reach all content.
+
+See [references/technical-stack.md](references/technical-stack.md) to wire up smooth scroll (Lenis/Locomotive setup, library tradeoffs) and [references/animation-patterns.md](references/animation-patterns.md) for pinning, horizontal galleries, and scroll-velocity sequences.
 
 ### 6. Performance & Loading
 
@@ -243,22 +186,11 @@ See: [references/case-studies.md](references/case-studies.md) for agency techniq
 - LCP under 2.5s -- optimize the critical rendering path for the hero
 - Loading states are designed elements -- custom skeletons and progress indicators, not afterthoughts
 
-**Product applications:**
-
-| Context | Application | Example |
-|---------|-------------|---------|
-| Font loading | Subset, preload, swap strategy | `<link rel="preload" as="font" crossorigin>` |
-| Image delivery | AVIF/WebP with responsive srcset | `<picture>` element with format fallbacks |
-| Animation perf | GPU-only properties with will-change hints | `transform: translate3d()` + `opacity` |
-
-**Copy patterns:**
-- Audit with Lighthouse, targeting 90+ on all metrics
-- Profile animations at 4x CPU throttle in Chrome DevTools; use `will-change` sparingly
-- Code-split and defer non-critical JS; dynamic imports for below-fold interactivity
+**Applications:** subset/preload/swap fonts (`<link rel="preload" as="font" crossorigin>`); AVIF/WebP with responsive `srcset` (`<picture>` fallbacks); GPU-only animation (`transform: translate3d()` + `opacity`). Audit with Lighthouse targeting 90+; code-split and defer non-critical JS.
 
 **Ethical boundary:** Fast-but-inaccessible is not a valid tradeoff -- never strip accessibility features or semantic HTML for speed.
 
-See: [references/technical-stack.md](references/technical-stack.md) for libraries, tools, and performance optimization techniques.
+See [references/technical-stack.md](references/technical-stack.md) when choosing libraries or hitting a perf budget -- the recommended stack and concrete font/image/animation optimization techniques.
 
 ### 7. Micro-Interactions
 
@@ -269,116 +201,78 @@ See: [references/technical-stack.md](references/technical-stack.md) for librarie
 **Why it works:** Micro-interactions signal that every pixel was considered. Individually subtle, collectively transformative -- users feel the care embedded in the experience.
 
 **Key insights:**
-- Custom cursor reflects brand personality (opt-in only -- ask the user first), with variants on interactive elements
+- Custom cursor reflects brand personality, with variants on interactive elements (subject to the opt-in rule above)
 - Branded `::selection` color that works on all backgrounds
 - Every link and card has a considered hover state -- scale, overlay, or meaningful transform
 - Focus states are visible AND beautiful -- on-brand indicators that keyboard users can clearly see
 - Loading, empty, 404, and error states are designed, helpful moments
 - Micro-typography is correct -- smart quotes, en/em dashes, no orphans on headlines, `text-wrap: balance` on key text
 
-**Product applications:**
+**Ethical boundary:** Focus states must meet keyboard-visibility requirements even when styled on-brand, and error/empty/404 states must be genuinely helpful, not just decorative.
 
-| Context | Application | Example |
-|---------|-------------|---------|
-| Cursor | Custom cursor with element variants (opt-in -- confirm first) | Dogstudio cursor system |
-| Buttons | Magnetic hover effect with subtle pull | Studio Freight magnetic buttons |
-| Focus | Styled focus-visible rings matching brand | Accessible + beautiful indicators |
-
-**Copy patterns:**
-- `::selection { background: var(--color-accent); color: var(--color-light); }`
-- Magnetic effect: compute cursor-to-button distance, apply proportional transform (cursor work is opt-in -- confirm first)
-- Smart quotes: `&ldquo;`/`&rdquo;` or auto-convert in the build tool
-
-**Ethical boundary:** Micro-interactions must enhance usability -- custom cursors only with explicit user approval and always functional, focus states meeting accessibility requirements, error states genuinely helpful.
+See [references/animation-patterns.md](references/animation-patterns.md) for copy-pasteable magnetic-button, cursor, and `::selection`/hover micro-interaction code.
 
 ## Design Process
 
-### 1. Concept First, Code Second
+Work in this order -- the sequence is the discipline:
 
-Before any code, define:
+1. **Concept before code.** Define four things first:
 ```
 BRAND ESSENCE: What single word captures the soul?
 VISUAL TENSION: What opposing forces create interest?
 SIGNATURE MOMENT: What will people screenshot and share?
 TECHNICAL AMBITION: What pushes the browser's limits?
 ```
-
-### 2. Design the Signature Moment First
-
-Do not start with the header -- start with the thing that defines the experience. Every 10/10 project has at least one moment people stop and share: a never-seen hero animation, typography so bold it becomes the visual, a scroll sequence that tells a story.
-
-**Questions to identify your signature:**
-1. What will people screenshot?
-2. What will they describe to colleagues?
-3. What will they try to reverse-engineer?
-4. What makes this unmistakably THIS project?
-
-### 3. Typography Sets Everything
-
-Choose your display typeface first. Let it dictate the color palette mood, animation style, spacing rhythm, and overall personality.
-
-### 4. Motion Is Not Polish
-
-Prototype animations early. Motion design happens alongside visual design, not after.
-
-### 5. Ship With Restraint
-
-3 things perfect beats 10 things mediocre. Cut ruthlessly.
+2. **Design the signature moment first** -- not the header. Every 10/10 project has at least one moment people stop and share (a never-seen hero animation, typography bold enough to BE the visual, a scroll sequence that tells a story). Pin it down by asking: what will people screenshot, describe to a colleague, try to reverse-engineer, and what makes it unmistakably THIS project?
+3. **Choose the display typeface next** -- it dictates the rest (Pillar 1).
+4. **Prototype motion alongside visual design, not after** -- motion is not polish (Pillar 3).
+5. **Ship with restraint** -- 3 things perfect beats 10 things mediocre. Cut ruthlessly.
 
 ## Implementation Notes
 
 1. **Conceptualize desktop-first, build mobile-first** -- dream big, implement progressively
-2. **Test on real devices** -- simulators lie about performance and feel
-3. **Design every state** -- hover, focus, loading, empty, error all matter
-4. **Own your constraints** -- every limitation is a design opportunity
-5. **Use project conventions** -- if Tailwind 4+ and/or shadcn/ui are available, extend their design tokens and components as the foundation for 10/10 craft rather than fighting them
+2. **Use project conventions** -- if Tailwind 4+ and/or shadcn/ui are available, extend their design tokens and components as the foundation for 10/10 craft rather than fighting them
 
 ## Common Mistakes
 
-| Mistake | Why It Fails | Fix |
+Each fix points to the pillar that defines the rule -- do not re-derive values here.
+
+| Mistake | Why It Fails | Fix (see) |
 |---------|-------------|-----|
-| Inter, Roboto, Arial, or system-ui as primary typeface | Application fonts signal generic, not premium | Premium foundries (Pangram Pangram, Dinamo, Grilli Type, Klim) or quality Google alternatives (Space Grotesk, Instrument Serif, Fraunces) |
-| Uniform type scale (everything within 2x) | No hierarchy, no gasping moments | Minimum 10:1 display-to-body ratio; viewport-filling type |
-| `ease`, `ease-in`, `ease-out`, or `linear` easing | Mechanical, lifeless -- instantly signals amateur | Custom cubic-beziers: expo out (0.16, 1, 0.3, 1), quart out (0.25, 1, 0.5, 1) |
-| Animating everything simultaneously | Visual noise, no hierarchy or narrative | Choreograph with 80ms stagger, sequence by importance |
-| Center-aligning everything | Safe but boring -- no tension or energy | Asymmetric compositions, grid offsets, bleeding elements |
-| Equal spacing everywhere | Monotony -- the eye has nowhere to rest | Vary spacing: dense sections then breathing room |
-| Pure #000000 black and #ffffff white | Lifeless and harsh | Warm variants: #0a0a0a, #fafaf9 |
-| Default browser scroll | Mechanical, treats all content equally | Lenis or Locomotive Scroll for weighted, physical feel |
-| Purple-to-blue gradient hero | The "AI gradient" -- generic trend-following | Signature color approach specific to the project |
-| No signature moment | Competent but forgettable | Design the screenshot-worthy moment FIRST |
+| Inter, Roboto, Arial, or system-ui as primary typeface | Application fonts signal generic, not premium | Premium foundry or quality Google alternative (Pillar 1) |
+| Uniform type scale (everything within 2x) | No hierarchy, no gasping moments | Hit the display-to-body ratio (Pillar 1) |
+| `ease`, `ease-in`, `ease-out`, or `linear` easing | Mechanical, lifeless -- instantly signals amateur | Banned -- use a custom cubic-bezier (Pillar 3) |
+| Animating everything simultaneously | Visual noise, no hierarchy or narrative | Stagger and sequence by importance (Pillar 3) |
+| Center-aligning everything | Safe but boring -- no tension or energy | Asymmetry, grid offsets, bleeding elements (Pillar 2) |
+| Equal spacing everywhere | Monotony -- the eye has nowhere to rest | Vary density: dense sections, then breathing room (Pillar 2) |
+| Pure #000000 / #ffffff | Lifeless and harsh | Warm variants (Pillar 4) |
+| Default browser scroll | Mechanical, treats all content equally | Smooth-scroll library (Pillar 5) |
+| Purple-to-blue gradient hero | The "AI gradient" -- generic trend-following | Signature color approach specific to the project (Pillar 4) |
+| No signature moment | Competent but forgettable | Design the screenshot-worthy moment FIRST (Process step 2) |
 | Any emoji in professional interfaces | Signals casual/amateur craft | Custom iconography or typographic treatments |
-| Parallax on text or critical content | Motion sickness, accessibility failures | Parallax only on decorative background elements |
-| Animations blocking interaction | Hostile UX | Keep all animation non-blocking; content always accessible |
+| Parallax on text or critical content | Motion sickness, accessibility failures | Parallax only on decorative background elements (Pillar 5) |
+| Animations blocking interaction | Hostile UX | Keep all animation non-blocking (Pillar 3) |
 | Unmodified Font Awesome icons | Template-level design | Custom icons, or heavily customize to match brand |
-| Default form styles | Breaks the illusion of craft instantly | Design every input, select, checkbox, and button |
+| Default form styles | Breaks the illusion of craft instantly | Design every input, select, checkbox, and button (Pillar 7) |
 
 ## Quick Diagnostic
 
-| Question | If No | Action |
+Score 1 point per row answered "yes", then map the count to the Scoring Rubric band: 11-12 -> 9-10, 8-10 -> 7-8, 5-7 -> 5-6, below 5 -> 0-4. State that score.
+
+| Question | If No | Fix (see) |
 |----------|-------|--------|
-| Does the hero typography make someone pause mid-scroll? | Display type not commanding | Push scale to 10:1+, pick a distinctive typeface, fill the viewport |
-| Would someone screenshot any section? | No signature moment | Make one section extraordinary -- animation, scale shift, or interaction |
+| Does the hero typography make someone pause mid-scroll? | Display type not commanding | Pillar 1 -- scale, distinctive typeface, viewport-filling |
+| Would someone screenshot any section? | No signature moment | Process step 2 -- make one section extraordinary |
 | Does the design still read when you blur your eyes? | Hierarchy too flat | Bigger headlines, more white space, stronger accents |
-| Are all easing curves custom (no `ease`/`linear`)? | Motion feels default | Expo out (0.16, 1, 0.3, 1) or quart out (0.25, 1, 0.5, 1) |
-| Is there asymmetric tension in the composition? | Layout feels safe | Offset from center, bleed images, vary section density |
-| Do the colors feel invented for THIS project? | Generic palette | Monochromatic tension, bold signature, or contextual shifting |
-| Is the page load choreographed? | Elements pop in at once | Staggered reveal: structure, hero, then supporting elements |
-| Does scroll feel custom and weighted? | Default browser scroll | Implement Lenis or Locomotive Scroll |
-| Are micro-details considered (selection, focus, cursor)? | Default browser behaviors remain | Branded selection, designed focus states; cursors only with user approval |
-| Is CLS near zero and LCP under 2.5s? | Performance undermines quality | Subset fonts, WebP/AVIF images, animate only transform/opacity |
-| Does every animation answer "why does this move?" | Decorative motion | Remove animation that serves no narrative, hierarchy, or guidance |
-| Are focus states both beautiful AND accessible? | One sacrificed for the other | On-brand indicators that meet WCAG visibility requirements |
-
-## Reference Files
-
-Consult these for detailed implementation:
-
-- **[references/typography.md](references/typography.md)**: Font pairing strategies, type scale systems, advanced CSS typography
-- **[references/animation-patterns.md](references/animation-patterns.md)**: Scroll animations, page transitions, micro-interactions with code
-- **[references/layout-systems.md](references/layout-systems.md)**: Grid frameworks, breakpoints, responsive patterns
-- **[references/technical-stack.md](references/technical-stack.md)**: Libraries, tools, performance optimization
-- **[references/case-studies.md](references/case-studies.md)**: Agency technique breakdowns (Locomotive, Studio Freight, AREA 17, Hello Monday, etc.)
+| Are all easing curves custom (no `ease`/`linear`)? | Motion feels default | Pillar 3 -- custom cubic-bezier |
+| Is there asymmetric tension in the composition? | Layout feels safe | Pillar 2 -- offset, bleed, vary density |
+| Do the colors feel invented for THIS project? | Generic palette | Pillar 4 -- monochromatic tension, signature, or contextual |
+| Is the page load choreographed? | Elements pop in at once | Pillar 3 -- staggered reveal sequence |
+| Does scroll feel custom and weighted? | Default browser scroll | Pillar 5 -- smooth-scroll library |
+| Are micro-details considered (selection, focus, cursor)? | Default browser behaviors remain | Pillar 7 -- branded selection, designed focus (cursors opt-in) |
+| Is CLS near zero and LCP under 2.5s? | Performance undermines quality | Pillar 6 -- subset fonts, WebP/AVIF, transform/opacity only |
+| Does every animation answer "why does this move?" | Decorative motion | Pillar 3 -- cut motion with no narrative or guidance |
+| Are focus states both beautiful AND accessible? | One sacrificed for the other | Pillar 7 -- on-brand indicators meeting WCAG visibility |
 
 ## Further Reading
 

--- a/traction-eos/SKILL.md
+++ b/traction-eos/SKILL.md
@@ -4,7 +4,7 @@ description: 'Implement the Entrepreneurial Operating System (EOS) to align visi
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.4.1"
 ---
 
 # Entrepreneurial Operating System (EOS)
@@ -17,7 +17,7 @@ A complete system for running a business with six key components. Designed for e
 
 ## Scoring
 
-**Goal: 10/10.** Score the business by counting satisfied rows in the Quick Diagnostic (one point per "yes", six rows): each component is either in place or it is not. Bands: **9-10** = all six diagnostic rows pass and rocks consistently hit 80%+ completion; **7-8** = five rows pass, one component weak; **5-6** = three to four rows pass; **3-4** = one to two rows pass; **<=2** = no operating rhythm in place. Always state the current score, the failing diagnostic rows, and the next action for each.
+**Goal: 10/10.** Score the business by how many of the six Quick Diagnostic rows pass (each component is either in place or not), mapped to the bands below. Bands: **9-10** = all six diagnostic rows pass and rocks consistently hit 80%+ completion; **7-8** = five rows pass, one component weak; **5-6** = three to four rows pass; **3-4** = one to two rows pass; **<=2** = no operating rhythm in place. Always state the current score, the failing diagnostic rows, and the next action for each.
 
 ## The Six Key Components
 

--- a/traction-eos/SKILL.md
+++ b/traction-eos/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: traction-eos
-description: 'Implement the Entrepreneurial Operating System (EOS) to align vision and execution across a company. Use when the user mentions "EOS", "V/TO", "quarterly rocks", "Level 10 meetings", "accountability chart", "IDS process", "Entrepreneurial Operating System", "business operating system", "my company feels chaotic", "we keep having the same problems", or "get the whole team aligned". Also trigger when a growing company needs meeting structure, goal-setting frameworks, or a systematic way to solve recurring organizational issues. Covers the six EOS components: Vision, People, Data, Issues, Process, Traction. For team motivation design, see drive-motivation. For lean experimentation, see lean-startup.'
+description: 'Implement the Entrepreneurial Operating System (EOS) to align vision and execution across a company. Use when the user mentions "EOS", "Entrepreneurial Operating System", "V/TO", "quarterly rocks", "Level 10 meetings", "accountability chart", "IDS process", "my company feels chaotic", "we keep having the same problems", or "get the whole team aligned". Also trigger when a growing company needs meeting structure, goal-setting frameworks, or a systematic way to solve recurring organizational issues. Covers the six EOS components: Vision, People, Data, Issues, Process, Traction. For team motivation design, see drive-motivation. For lean experimentation, see lean-startup.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.3.0"
+  version: "1.4.0"
 ---
 
 # Entrepreneurial Operating System (EOS)
@@ -17,15 +17,13 @@ A complete system for running a business with six key components. Designed for e
 
 ## Scoring
 
-**Goal: 10/10.** Rate any business 0-10 on EOS component strength: a 10/10 means all six components are strong, meetings are productive, and quarterly rocks are consistently achieved. Always state the current score and the improvements needed to reach 10/10.
+**Goal: 10/10.** Score the business by counting satisfied rows in the Quick Diagnostic (one point per "yes", six rows): each component is either in place or it is not. Bands: **9-10** = all six diagnostic rows pass and rocks consistently hit 80%+ completion; **7-8** = five rows pass, one component weak; **5-6** = three to four rows pass; **3-4** = one to two rows pass; **<=2** = no operating rhythm in place. Always state the current score, the failing diagnostic rows, and the next action for each.
 
 ## The Six Key Components
 
 ```
 Vision → People → Data → Issues → Process → Traction
 ```
-
-Every business is built on these six components. EOS strengthens all six.
 
 ### 1. Vision Component
 
@@ -48,7 +46,7 @@ Every business is built on these six components. EOS strengthens all six.
 
 **Key insight:** If the leadership team can't agree on the V/TO, you have a bigger problem — alignment comes first.
 
-See: [references/vto.md](references/vto.md) for V/TO templates and exercises.
+See [references/vto.md](references/vto.md) when filling in the V/TO — the eight-question template and the off-site exercise sequence.
 
 ### 2. People Component
 
@@ -78,7 +76,7 @@ Visionary ←→ Integrator
 - Wrong person, right seat → coach or exit (hardest call)
 - Wrong person, wrong seat → exit immediately
 
-See: [references/people.md](references/people.md) for accountability chart and People Analyzer templates.
+See [references/people.md](references/people.md) when building the accountability chart or running People Analyzer — templates plus GWC scoring guidance.
 
 ### 3. Data Component
 
@@ -102,7 +100,7 @@ See: [references/people.md](references/people.md) for accountability chart and P
 
 **Metric selection:** If you had to go on vacation for 4 weeks, what 5-15 numbers would tell you how the business is doing?
 
-See: [references/data.md](references/data.md) for scorecard templates and metric selection.
+See [references/data.md](references/data.md) when building the scorecard — templates plus how to pick leading-indicator metrics.
 
 ### 4. Issues Component
 
@@ -126,7 +124,7 @@ See: [references/data.md](references/data.md) for scorecard templates and metric
 
 **Common IDS failures:** discussing symptoms instead of root cause, rehashing the same issue weekly, ending without clear action items.
 
-See: [references/issues.md](references/issues.md) for IDS facilitation guides.
+See [references/issues.md](references/issues.md) when facilitating IDS — a Five Whys worked example and tangent-control tactics.
 
 ### 5. Process Component
 
@@ -146,9 +144,9 @@ See: [references/issues.md](references/issues.md) for IDS facilitation guides.
 5. Follow up (3 touches in 7 days)
 6. Close or disqualify
 
-**Followed By All (FBA):** Document it, train on it, measure compliance, update quarterly — a documented process nobody follows is shelf-ware.
+**Followed By All (FBA):** Document it, train on it, measure compliance, update quarterly.
 
-See: [references/process.md](references/process.md) for process documentation templates.
+See [references/process.md](references/process.md) when documenting a core process — full templates and a worked HR/sales/ops example.
 
 ### 6. Traction Component
 
@@ -169,7 +167,7 @@ The 3-7 most important things to accomplish in the next 90 days. Ninety days is 
 
 **Rock scoring:** Done = checked off (no partial credit); not done = carried forward or dropped. Target 80%+ completion. Beware rocks that are just "business as usual" — they don't move the needle.
 
-See: [references/rocks.md](references/rocks.md) for rock-setting exercises.
+See [references/rocks.md](references/rocks.md) when setting quarterly rocks — the binary done-test, the nine-row mistakes table, and a mid-quarter check-in.
 
 #### Level 10 Meeting (Weekly Leadership Meeting)
 
@@ -192,7 +190,7 @@ See: [references/rocks.md](references/rocks.md) for rock-setting exercises.
 - Rate the meeting 1-10 at the end (hence "Level 10"); below 8 means discuss what to improve
 - To-dos are 7-day action items with an owner; done = 100% complete; target 90%+ completion
 
-See: [references/level-10.md](references/level-10.md) for meeting facilitation guides.
+See [references/level-10.md](references/level-10.md) when running or fixing a Level 10 — facilitation script and how to interpret the meeting rating.
 
 ## EOS Implementation Timeline
 
@@ -208,7 +206,7 @@ Typical rollout: 2 years to full implementation.
 
 **Self-implementation** (read the book, follow the tools — free, slower) vs. **EOS Implementer** (certified facilitator — faster, expensive).
 
-See: [references/implementation.md](references/implementation.md) for the rollout guide.
+See [references/implementation.md](references/implementation.md) when planning the rollout — phase-by-phase sequencing and the self-vs-Implementer decision. For examples of how real companies sequenced it, see [references/case-studies.md](references/case-studies.md).
 
 ## Organizational Checkup
 
@@ -230,11 +228,11 @@ Rate the company 1-5 on each statement:
 | Mistake | Why It Fails | Fix |
 |---------|-------------|------|
 | **Skipping Level 10s** | Weekly rhythm lost, issues pile up | Protect the meeting, never cancel |
-| **Too many rocks** | No focus, nothing gets done | Max 7 company rocks, 3-7 per person |
-| **Vague rocks** | Can't tell if done | SMART rocks with clear criteria |
 | **No scorecard** | Managing by gut, constant surprises | Choose 5-15 weekly numbers |
 | **Wrong people kept** | Drags the entire team down | People Analyzer, make the tough calls |
 | **V/TO not shared** | Team doesn't know the vision | Share with the entire company |
+
+For rock-specific mistakes (too many, too vague, business-as-usual, mid-quarter changes), see [references/rocks.md](references/rocks.md) — full nine-row table with fixes.
 
 ## Quick Diagnostic
 
@@ -246,18 +244,6 @@ Rate the company 1-5 on each statement:
 | Issues solved permanently? | Same problems repeat | IDS in Level 10s |
 | Core processes documented? | Inconsistency | Document the top 5 processes |
 | 90-day priorities set and tracked? | No traction | Set quarterly rocks |
-
-## Reference Files
-
-- [vto.md](references/vto.md): Vision/Traction Organizer templates, eight questions
-- [people.md](references/people.md): Accountability chart, People Analyzer, GWC
-- [data.md](references/data.md): Scorecard templates, metric selection
-- [issues.md](references/issues.md): IDS process, facilitation, issue types
-- [process.md](references/process.md): Core process documentation templates
-- [rocks.md](references/rocks.md): Rock-setting exercises, SMART rocks
-- [level-10.md](references/level-10.md): Meeting agenda, facilitation, rating
-- [implementation.md](references/implementation.md): EOS rollout timeline, self-implementation guide
-- [case-studies.md](references/case-studies.md): Companies that implemented EOS successfully
 
 ## Further Reading
 

--- a/ux-heuristics/SKILL.md
+++ b/ux-heuristics/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: ux-heuristics
-description: 'Evaluate and improve interface usability using heuristic analysis. Use when the user mentions "usability audit", "UX review", "users are confused", "heuristic evaluation", "form usability", "navigation problems", "Nielsen heuristics", "cognitive walkthrough", "usability testing", "is this easy to use", "find usability problems", or "people get lost in our app". Also trigger when reviewing a design for usability issues, improving form-completion rates, or evaluating information architecture and navigation. Covers Nielsen''s 10 heuristics, severity ratings, and information architecture. For visual design fixes, see refactoring-ui. For conversion-focused audits, see cro-methodology.'
+description: 'Evaluate and improve interface usability using heuristic analysis. Use when the user mentions "usability audit", "users are confused", "form usability", "navigation problems", "Nielsen heuristics", "cognitive walkthrough", or "is this easy to use". Also trigger when reviewing a design for usability issues, improving form-completion rates, or evaluating information architecture and navigation. Covers Krug''s laws, Nielsen''s 10 heuristics, severity ratings, dark-pattern recognition, and accessibility. For visual design fixes, see refactoring-ui. For conversion-focused audits, see cro-methodology.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.5.0"
+  version: "1.6.0"
 ---
 
 # UX Heuristics Framework
@@ -13,13 +13,15 @@ Practical usability principles for evaluating and improving user interfaces. Use
 
 ## Core Principle
 
-**"Don't Make Me Think"** — every page should be self-evident. If something requires thinking, it's a usability problem. Users have limited patience and cognitive bandwidth, so design for scanning, satisficing, and muddling through — because that's what users actually do.
+**"Don't Make Me Think"** — every page should be self-evident. If something requires thinking, it's a usability problem. Users have limited patience and cognitive bandwidth, so design for the scanning, satisficing, and muddling-through behavior described above.
 
 ## Scoring
 
-**Goal: 10/10.** Rate any interface 0-10 against the principles below. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Audit the interface, rate every issue on the severity scale below, then score the interface from its Quick Diagnostic results: start at 10 and subtract per failed diagnostic row, weighted by the worst severity it triggers (catastrophic/major rows cost ~2, minor/cosmetic ~1). Bands: **9-10** = no severity-3+ issues and ≤1 failed diagnostic row; **6-8** = some major issues or several failed rows; **3-5** = a catastrophic issue or many failed rows; **≤2** = core tasks blocked. Always state the current score, the highest-severity issues, and the specific fixes needed to reach 10/10.
 
-## Krug's Three Laws of Usability
+## Krug's Usability Principles
+
+Laws 1-3 are Krug's Three Laws of Usability; #4, the Trunk Test, is his navigation orientation check.
 
 ### 1. Don't Make Me Think
 
@@ -48,7 +50,7 @@ Practical usability principles for evaluating and improving user interfaces. Use
 
 **Ethical boundary:** Clarity should serve users — never use plain language as a veneer to hide unfavorable terms.
 
-See: [references/krug-principles.md](references/krug-principles.md) for full Krug methodology, scanning behavior, and the click philosophy.
+See: [references/krug-principles.md](references/krug-principles.md) when you need the full Krug method — scanning/satisficing/muddling psychology, the goodwill reservoir, homepage and tagline guidance, and the $0 usability-testing protocol (how many users, the test script).
 
 ### 2. It Doesn't Matter How Many Clicks
 
@@ -80,8 +82,6 @@ See: [references/krug-principles.md](references/krug-principles.md) for full Kru
 
 **Core concept:** Remove half the words on each page, then half of what's left. Brevity makes useful content prominent and respects the user's time.
 
-**Why it works:** Users scan — every unnecessary word competes with the words that matter.
-
 **Key insights:**
 - Happy-talk ("Welcome to our website!") wastes space
 - Instructions nobody reads should be removed
@@ -104,30 +104,15 @@ See: [references/krug-principles.md](references/krug-principles.md) for full Kru
 
 ### 4. The Trunk Test
 
-**Core concept:** Drop a user on any random page (like being released from a car trunk at a random spot) — they should instantly answer: What site is this? What page? What are the major sections? What are my options? Where am I in the hierarchy? Where's search?
+**Core concept:** Drop a user on any random page (like being released from a car trunk at a random spot) — they should instantly answer six orientation questions: What site is this? What page? What are the major sections? What are my options here? Where am I in the hierarchy? Where's search?
 
 **Why it works:** Good navigation gives constant orientation. Users who can't tell where they are feel lost and leave.
 
-**Key insights:**
-- Site ID (logo) and page name must be visible at all times
-- Major sections and local options must be evident
-- Breadcrumbs show position in the hierarchy
-- Search must be findable on every page
+Apply it as the navigation check: page titles must match the link the user clicked, a "you are here" indicator (highlighted nav item, bold breadcrumb) must be present, and section headings must orient ("Your Account > Billing" not just "Settings").
 
-**Product applications:**
+**Ethical boundary:** Navigation labels must honestly represent site structure — never use misleading labels to funnel users into marketing pages.
 
-| Context | Application | Example |
-|---------|-------------|---------|
-| **Global nav** | Persistent site ID and sections | Logo top-left, main nav always visible |
-| **Page headers** | Clear, descriptive titles | "Running Shoes - Men's" not just "Products" |
-| **Breadcrumbs** | Hierarchy on all inner pages | "Home > Products > Shoes > Running" |
-
-**Copy patterns:**
-- Page titles that match the link the user clicked
-- "You are here" indicators (highlighted nav item, bold breadcrumb)
-- Section headings that orient: "Your Account > Billing" not just "Settings"
-
-**Ethical boundary:** Navigation should honestly represent site structure — never use misleading labels to funnel users into marketing pages.
+See: [references/krug-principles.md](references/krug-principles.md) when running the Trunk Test or designing navigation — it maps each of the six questions to the page element that answers it, plus breadcrumb and permanent-navigation rules.
 
 ## Nielsen's 10 Usability Heuristics
 
@@ -161,7 +146,7 @@ Error messages need three parts: what happened, why, and how to fix it. Plain la
 ### 10. Help and Documentation
 Help should be searchable, task-focused ("How to..." not technical reference), and contextual (tooltips, inline hints, guided tours).
 
-See: [references/nielsen-heuristics.md](references/nielsen-heuristics.md) for detailed examples, product applications, copy patterns, and ethical boundaries for all 10 heuristics.
+See: [references/nielsen-heuristics.md](references/nielsen-heuristics.md) when auditing against a specific heuristic — it expands each of the 10 into good-implementation / common-violation / severity tables with copy patterns and ethical boundaries.
 
 ## Severity Rating Scale
 
@@ -176,6 +161,8 @@ Rate each issue found in an audit:
 | **4** | Catastrophic | Prevents task completion | Fix immediately |
 
 Weigh three factors: **frequency** (how often it occurs), **impact** (how severe when it occurs), **persistence** (one-time or ongoing).
+
+See: [references/audit-template.md](references/audit-template.md) when running a full heuristic evaluation — a structured per-screen template that captures issues, severity, and recommended fixes in a consistent format.
 
 ## Common Mistakes
 
@@ -196,6 +183,8 @@ Weigh three factors: **frequency** (how often it occurs), **impact** (how severe
 | **Low contrast text** | Unreadable for many users | WCAG AA minimum (4.5:1 contrast) |
 | **Inconsistent nav location** | Users can't find navigation | Fixed position, same place on every page |
 | **Broken back button** | Violates the browser contract | Never hijack or break browser history |
+
+See: [references/wcag-checklist.md](references/wcag-checklist.md) when auditing accessibility (contrast, keyboard, screen-reader, focus) — a complete WCAG 2.1 AA checklist with testing tools. See [references/cultural-ux.md](references/cultural-ux.md) when designing for global audiences — RTL layouts, color meanings, form/name/date conventions, and localization pitfalls.
 
 ## Quick Diagnostic
 
@@ -220,13 +209,13 @@ Heuristics sometimes contradict each other. When they do:
 - **Efficiency vs. Error Prevention**: prefer undo over confirmation dialogs
 - **Discoverability vs. Minimalism**: primary actions visible, secondary hidden
 
-See: [references/heuristic-conflicts.md](references/heuristic-conflicts.md) for resolution frameworks.
+See: [references/heuristic-conflicts.md](references/heuristic-conflicts.md) when two heuristics pull in opposite directions and the four rules above don't settle it — resolution frameworks with worked trade-off examples.
 
 ## Dark Patterns Recognition
 
 Dark patterns violate heuristics deliberately to manipulate users: forced continuity (hard to cancel), roach motel (easy in, hard out), confirmshaming (guilt-based options), hidden costs (surprise fees at checkout).
 
-See: [references/dark-patterns.md](references/dark-patterns.md) for the complete taxonomy and ethical alternatives.
+See: [references/dark-patterns.md](references/dark-patterns.md) when you suspect a design manipulates rather than serves users — the complete taxonomy, ethical alternatives, and relevant regulations.
 
 ## When to Use Each Method
 
@@ -236,16 +225,6 @@ See: [references/dark-patterns.md](references/dark-patterns.md) for the complete
 | User testing | After heuristic fixes | 2-4 hours | Real behavior |
 | A/B testing | When optimizing | Days-weeks | Statistical validation |
 | Analytics review | Ongoing | 30 min | Patterns and problems |
-
-## Reference Files
-
-- [krug-principles.md](references/krug-principles.md): Full Krug methodology, scanning behavior, navigation clarity
-- [nielsen-heuristics.md](references/nielsen-heuristics.md): Detailed heuristic explanations with examples
-- [audit-template.md](references/audit-template.md): Structured heuristic evaluation template
-- [dark-patterns.md](references/dark-patterns.md): Categories, examples, ethical alternatives, regulations
-- [wcag-checklist.md](references/wcag-checklist.md): Complete WCAG 2.1 AA checklist, testing tools
-- [cultural-ux.md](references/cultural-ux.md): RTL, color meanings, form conventions, localization
-- [heuristic-conflicts.md](references/heuristic-conflicts.md): When heuristics contradict, resolution frameworks
 
 ## Further Reading
 

--- a/web-typography/SKILL.md
+++ b/web-typography/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: web-typography
-description: 'Select, pair, and implement typefaces for web projects. Use when the user mentions "font pairing", "which typeface", "line height", "responsive typography", "web font loading", "type hierarchy", "variable fonts", "FOUT/FOIT", "typographic scale", "choose a font", "improve readability", or "the text is hard to read". Also trigger when choosing between system fonts and web fonts, optimizing font-loading performance, or designing readable long-form content. Covers readability evaluation, CSS implementation, and performance optimization. For overall UI design systems, see refactoring-ui. For dramatic typographic experiences, see top-design.'
+description: 'Select, pair, and implement typefaces for web projects. Use when the user mentions "font pairing", "which typeface", "line height", "responsive typography", "web font loading", "type hierarchy", "variable fonts", "FOUT/FOIT", "typographic scale", or "the text is hard to read". Also trigger when choosing between system fonts and web fonts, optimizing font-loading performance, or designing readable long-form content. Covers readability evaluation, CSS implementation, and performance optimization. For overall UI design systems, see refactoring-ui. For dramatic typographic experiences, see top-design.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.4.0"
+  version: "1.5.0"
 ---
 
 # Web Typography
@@ -17,7 +17,7 @@ A practical guide to choosing, pairing, and implementing typefaces for the web. 
 
 ## Scoring
 
-**Goal: 10/10.** Rate any typography implementation 0-10 against the principles below. Always state the current score and the specific improvements needed to reach 10/10.
+**Goal: 10/10.** Score = number of the 10 Quick Diagnostic rows the implementation satisfies. Bands: **9-10** = body 16px+, measure under 75ch, line-height 1.4+, clear level contrast, font payload under 200KB, fallbacks set, survives 200% zoom; **5-6** = readable but missing measure control, fallbacks, or zoom resilience; **<=3** = sub-16px body, no measure cap, FOIT, or unreadable hierarchy. Always state the current score and the specific diagnostic rows failing.
 
 ## Two Contexts for Type
 
@@ -36,7 +36,7 @@ All typography falls into two categories:
 
 **Core concept:** Understanding reading mechanics is the foundation for every typography decision. Eyes don't scan smoothly — they jump in bursts.
 
-**Why it works:** When typography aligns with how the brain processes text — word shapes, consistent rhythm, distinct letterforms — readers absorb content faster with less fatigue. Fighting these mechanics creates friction that drives readers away.
+**Why it works:** Fighting these mechanics creates friction that drives readers away; aligning with them lets readers absorb content faster with less fatigue.
 
 **Key insights:**
 - **Saccades** — eyes jump in 7-9 character bursts; line length and letter spacing directly affect saccade efficiency
@@ -61,9 +61,7 @@ All typography falls into two categories:
 }
 ```
 
-**Ethical boundary:** Prioritize reader comprehension over visual novelty — sacrificing readability for aesthetics excludes readers.
-
-See: [references/typeface-anatomy.md](references/typeface-anatomy.md) for terminology, letterform parts, and classification systems.
+See: [references/typeface-anatomy.md](references/typeface-anatomy.md) when you need to name letterform parts (x-height, counter, aperture) or place a face in a classification system to justify a choice.
 
 ### 2. Evaluating Typefaces
 
@@ -93,9 +91,9 @@ body { font-size: 16px; }
 h1 { font-size: 3rem; }
 ```
 
-**Ethical boundary:** Always verify licensing — unlicensed fonts create legal risk and undermine the type design community.
+**Ethical boundary:** Always verify the web license before shipping a font — desktop/print licenses rarely cover web embedding, and unlicensed use creates real legal liability.
 
-See: [references/evaluating-typefaces.md](references/evaluating-typefaces.md) for detailed quality assessment criteria and structural analysis.
+See: [references/evaluating-typefaces.md](references/evaluating-typefaces.md) when vetting a candidate face — full quality checklist, red-flags table, and the structural criteria to inspect.
 
 ### 3. Choosing Typefaces
 
@@ -126,7 +124,7 @@ body {
 }
 ```
 
-**Ethical boundary:** Never choose trendiness over readability — typography that excludes readers with lower vision fails its purpose.
+See: [references/evaluating-typefaces.md](references/evaluating-typefaces.md) when narrowing finalists or weighing free vs. paid faces — the side-by-side comparison method and quality-option shortlists.
 
 ### 4. Pairing Typefaces
 
@@ -155,9 +153,7 @@ h1, h2, h3 { font-family: 'Playfair Display', Georgia, serif; }
 body { font-family: 'Source Sans Pro', -apple-system, sans-serif; }
 ```
 
-**Ethical boundary:** When in doubt, use one family with weight variation — forced pairings add complexity that serves the designer's ego, not the reader.
-
-See: [references/pairing-strategies.md](references/pairing-strategies.md) for specific combinations, contrast methods, and proven pairings.
+See: [references/pairing-strategies.md](references/pairing-strategies.md) when picking a second face — proven combinations, the contrast-type table, and same-designer/superfamily shortcuts.
 
 ### 5. Typographic Measurements
 
@@ -192,15 +188,13 @@ h1, h2 { line-height: 1.1; }      /* headlines: 1.1-1.25 */
 .body-text { line-height: 1.6; }  /* body: 1.5-1.7 */
 ```
 
-**Ethical boundary:** Never cram text into tiny sizes or narrow columns to "fit the design" — that prioritizes visual arrangement over human comprehension.
-
-See: [references/responsive-typography.md](references/responsive-typography.md) for fluid sizing and viewport-based measurement strategies.
+See: [references/responsive-typography.md](references/responsive-typography.md) when writing the `clamp()` formulas — how to derive min/preferred/max and viewport-based measurement strategies.
 
 ### 6. Building Type Hierarchies
 
 **Core concept:** Hierarchy tells readers what matters most. Create distinction through controlled variation in size, weight, and color — but don't pull all three levers at once.
 
-**Why it works:** When differences between levels are deliberate and consistent, readers scan a page and instantly understand its structure. Without hierarchy, everything competes and nothing wins.
+**Why it works:** Deliberate, consistent differences between levels let readers grasp page structure at a glance; without hierarchy everything competes and nothing wins.
 
 **Key insights:**
 - **Three levers** — size, weight, color; vary one or two between adjacent levels, never all three
@@ -226,9 +220,9 @@ body { font-size: 1rem; font-weight: 400; color: #333; }
 h1, h2, h3 { margin: 1.5em 0 0.5em; line-height: 1.2; }
 ```
 
-**Ethical boundary:** Hierarchy must guide readers honestly — burying fees in small text or spotlighting manipulative CTAs weaponizes typography against the reader.
+**Ethical boundary:** Don't bury fees, disclaimers, or opt-outs in small or low-contrast type to demote what users need to see — hierarchy that hides material information weaponizes typography against the reader.
 
-See: [references/css-implementation.md](references/css-implementation.md) for complete hierarchy implementation patterns and variable font techniques.
+See: [references/css-implementation.md](references/css-implementation.md) when implementing the CSS — full hierarchy patterns, `@font-face` loading, `font-variation-settings` axes, and subsetting with pyftsubset.
 
 ### 7. Responsive Typography and Web Font Performance
 
@@ -293,14 +287,6 @@ h1 { font-size: clamp(2rem, 1.5rem + 2vw, 3.5rem); }
 | Does the page work at 200% zoom? | Accessibility failure for low vision | Fix overflow and truncation at 200% |
 | Are headings free of orphaned words? | Trailing words look unfinished | `text-wrap: balance` or manual breaks |
 | Are links visually distinct? | Users can't find interactive elements | Color and/or underline distinction |
-
-## Reference Files
-
-- [typeface-anatomy.md](references/typeface-anatomy.md): Terminology, letterform parts, classification systems
-- [evaluating-typefaces.md](references/evaluating-typefaces.md): Quality assessment, structural analysis, technical requirements
-- [pairing-strategies.md](references/pairing-strategies.md): Combining typefaces, contrast methods, proven combinations
-- [responsive-typography.md](references/responsive-typography.md): Fluid type, viewport units, breakpoint strategies
-- [css-implementation.md](references/css-implementation.md): @font-face, loading strategies, variable fonts, performance
 
 ## Further Reading
 

--- a/working-with-legacy-code/SKILL.md
+++ b/working-with-legacy-code/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: working-with-legacy-code
-description: 'Safely change and test untested codebases using Feathers'' "Working Effectively with Legacy Code". Use when the user mentions "legacy code", "no tests", "untested codebase", "how do I test this", "seams", "characterization tests", "sprout method", "afraid to change this code", "monster method", "dependency breaking", "inherited a messy codebase", or "scared to touch this code". Also trigger when changing code without tests safely, getting a class under test when constructors, statics, or singletons block it, adding features to tangled modules, or planning incremental test coverage for an old codebase. Covers the legacy-code change algorithm, seams, characterization tests, sprout/wrap, and dependency-breaking techniques. For refactoring code that already has tests, see refactoring-patterns. For day-to-day code quality, see clean-code.'
+description: 'Safely change and test untested codebases using Feathers'' "Working Effectively with Legacy Code". Use when the user mentions "legacy code", "no tests", "untested codebase", "how do I test this", "seams", "characterization tests", "golden master", "sprout method", "afraid to change this code", "monster method", "dependency breaking", or "inherited a messy codebase". Also trigger when changing code without tests safely, getting a class under test when constructors, statics, or singletons block it, adding features to tangled modules, or planning incremental test coverage for an old codebase. Covers the legacy-code change algorithm, seams, characterization tests, sprout/wrap, and dependency-breaking techniques. For refactoring code that already has tests, see refactoring-patterns. For day-to-day code quality, see clean-code.'
 license: MIT
 metadata:
   author: wondelai
-  version: "1.1.0"
+  version: "1.2.0"
 ---
 
 # Working Effectively with Legacy Code
@@ -48,7 +48,7 @@ A field manual for changing code that has no tests, distilled from Michael C. Fe
 | PR mixing cleanup and a feature | Split into structure-only and behavior-only commits | Extract and rename first, tests green, then add the discount rule |
 | "It's just a one-line change" | Find the nearest test point first | One pin test at the public method that calls the private one you edit |
 
-See: [references/change-algorithm.md](references/change-algorithm.md)
+See [references/change-algorithm.md](references/change-algorithm.md) when running the five steps on a real change — the algorithm as a working procedure with change-point/test-point checklists and triage for "no time" situations.
 
 ### 2. Seams: Where to Pry Code Apart
 
@@ -72,7 +72,7 @@ See: [references/change-algorithm.md](references/change-algorithm.md)
 | Module calls a top-level `send_email()` | Import/link seam | `mocker.patch("billing.send_email")` or `jest.mock("./mailer")` |
 | Logic reads the wall clock directly | Seam at the clock | Inject a `now()` provider; tests freeze time |
 
-See: [references/seams.md](references/seams.md)
+See [references/seams.md](references/seams.md) when hunting a seam in a specific stack — the seam catalog with code, enabling points, and seams in modern tooling (DI containers, jest.mock, pytest monkeypatch, clock and config seams).
 
 ### 3. Characterization Tests
 
@@ -96,13 +96,13 @@ See: [references/seams.md](references/seams.md)
 | Legacy report generator | Golden master diff | Generate the report, compare to a checked-in master file |
 | Off-by-one found while pinning | Pin the wrong value, document it | `assert days == 30  # BUG? expected 31 — TICKET-482` |
 
-See: [references/characterization-tests.md](references/characterization-tests.md)
+See [references/characterization-tests.md](references/characterization-tests.md) when writing your first probe through to a pinned suite — golden masters, snapshot tests done right, and a worked before/after refactor.
 
 ### 4. Sprout and Wrap: Changing Without Tests First
 
 **Core concept:** When you genuinely cannot get the area under test today, don't weave new logic into the untested mass. Sprout Method or Sprout Class: write the new behavior as fresh, fully tested code and call it from a single line in the legacy spot. Wrap Method or Wrap Class: rename the old code aside and add behavior before or after the call to it, decorator-style.
 
-**Why it works:** New code in a fresh method or class can be test-driven even when its host can't be instantiated in a harness. The untested host changes by one call site — old behavior remains byte-for-byte intact, new behavior arrives fully verified, and the risk stays contained to a single line.
+**Why it works:** New code in a fresh method or class can be test-driven even when its host can't be instantiated in a harness — testability no longer waits on getting the host into a harness. The untested host changes by exactly one call site, so the unverified blast radius is a single line instead of the whole method.
 
 **Key insights:**
 - Sprout Method when new logic plugs in at one point; Sprout Class when the host class won't even instantiate in a test harness
@@ -142,7 +142,7 @@ See: [references/characterization-tests.md](references/characterization-tests.md
 | Static `Billing.charge()` called everywhere | Introduce Instance Delegator | Instance `charge()` delegates to the static; tests override it |
 | 900-line method hoarding locals | Break Out Method Object | `new RateCalculation(order, rates).run()` — locals become fields |
 
-See: [references/dependency-breaking.md](references/dependency-breaking.md)
+See [references/dependency-breaking.md](references/dependency-breaking.md) when a specific blocker stops instantiation or sensing — before/after code for each technique plus a decision table mapping blockers to the right move.
 
 ### 6. Untangling and Understanding
 
@@ -166,7 +166,7 @@ See: [references/dependency-breaking.md](references/dependency-breaking.md)
 | Feature due in a 5,000-line class | Pinch-point tests, then sprout | Cover `postInvoice()`, sprout the new rule as a class |
 | Code nobody on the team understands | Scratch refactor on a branch | Extract and rename to learn, revert, plan the real moves |
 
-See: [references/case-studies.md](references/case-studies.md)
+See [references/case-studies.md](references/case-studies.md) when you want a full worked walkthrough — three scenarios: a feature in an untested 800-line service, a singleton-ridden module brought under test, and a monster method tamed before a bug fix.
 
 ## Common Mistakes
 
@@ -188,19 +188,11 @@ See: [references/case-studies.md](references/case-studies.md)
 | Do tests cover the code you're about to change? | You're editing and praying | Run the change algorithm; pin behavior before editing |
 | Can you construct the class in a test harness? | Dependencies block separation | Parameterize Constructor, Extract Interface, or Sprout Class |
 | Can a test sense the effect of your change? | Effects are invisible to assertions | Find a sensing point; Extract and Override Getter |
-| Is this commit behavior-only or structure-only? | Mixed changes are unverifiable | Split it; run the tests between the two |
+| Is this commit behavior-only or structure-only? | Mixed | Split it; run the tests between the two |
 | Do you know everything this change can affect? | Unknown blast radius | Draw an effect sketch; test at the pinch points |
-| Do your assertions state observed behavior? | You're testing wishes, not code | Probe, read the failure, pin the actual value |
-| Is the seam you chose the cheapest one available? | Needless surgery risks behavior | Prefer constructor parameters and import seams first |
+| Do your assertions state observed behavior? | Testing wishes | Probe, read the failure, pin the actual value |
+| Is the seam you chose the cheapest one available? | Needless surgery | Prefer constructor parameters and import seams first |
 | Will the code be better covered after this change? | The next change costs as much as this one | Leave at least one pin test at the nearest test point |
-
-## Reference Files
-
-- [change-algorithm.md](references/change-algorithm.md): The five-step algorithm as a working procedure — change points, test points, safety checklists, triage for "no time" situations, behavior-vs-structure discipline
-- [seams.md](references/seams.md): Seam catalog with code — object, link/import, and preprocessing seams, enabling points, seams in modern stacks (DI containers, jest.mock, pytest monkeypatch, clock and config seams)
-- [characterization-tests.md](references/characterization-tests.md): From first failing probe to a pinned suite — golden masters, snapshot tests done right, and a worked before/after refactor
-- [dependency-breaking.md](references/dependency-breaking.md): Before/after code for each major technique plus a decision table mapping blockers to techniques
-- [case-studies.md](references/case-studies.md): Three scenarios — a feature in an untested 800-line service, a singleton-ridden module brought under test, a monster method tamed before a bug fix
 
 ## Further Reading
 


### PR DESCRIPTION
## What

Audited all 50 skills against the **writing-great-skills** rubric, then edited every one to genuinely reach **9–10/10** by fixing the defects the audit found — not by gaming the score.

Done with multi-agent orchestration: one agent per skill applied a shared fix-playbook to its own files, an **independent auditor re-scored each edited file fresh** (pass only at ≥9.0), and 10 stragglers got a remediation pass.

## The fixes (systemic, from the audit)

| Defect (audited frequency) | Fix |
|---|---|
| `no_op` — platitude "Ethical boundary" / restating "Why it works" (44/50) | Cut unless the line states a concrete, behavior-changing constraint |
| `duplication` — trailing "Reference Files" roster, overlapping tables, SKILL↔reference (42/50) | Single source of truth: **48 rosters removed**, tables merged, detail kept in one place |
| `poor_disclosure` — bare `See: references/X.md` (24/50) | Upgraded to **when-to-read** pointers at point of need |
| `weak_description` — synonym-padded triggers (43/50) | Collapsed to one trigger per distinct branch; kept cross-refs |
| fuzzy Scoring rubric | Concrete checkable bands tied to the Quick Diagnostic |
| `sprawl` — 8 files >300 lines | Trimmed via the above (not by cutting substance) |
| **bug** — `influence-psychology` 6-vs-7 principle mismatch | Reconciled to seven; **Unity** now has a description trigger (`shared identity`, `in-group`) |

## Verification (objective, not agent self-scores)

- **Net −751 lines** (857 insertions / 1608 deletions) — pruning, not padding
- **Scope clean**: 50 `SKILL.md` + 5 `references/` changed; **0** README / marketplace.json / CLAUDE.md
- **50/50 YAML frontmatters parse** (name + description + version present)
- Every skill version bumped (MINOR, per repo policy)
- Spot-checked top-design (−106 lines): all 7 pillars + scoring/diagnostic intact, leading words preserved
- Independent re-score: **all 50 at 9.0–9.4** (was 6.8–9.1, mean 8.3)

## Notes

- 3 files remain slightly over the ~300-line guide (`one-page-marketing` 343, `influence-psychology` 311, `hundred-million-offers` 309) — the re-scorer judged the remaining length to be dense, behavior-bearing framework content, so they pass at 9.0–9.2. Further cuts would mean deleting substance.
- README/marketplace skill descriptions were intentionally left alone; the tightened YAML `description` triggers are what the rubric scores.

Not auto-merged — opening for your review given the breadth (55 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ygbNRWuZjaizDpcLEQ6jj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated many framework guides with clearer, diagnosis-driven scoring rubrics and instructions on reporting current scores, failing areas, and required fixes.
  * Replaced long reference lists with more contextual inline links, strengthened “See … when …” guidance, and improved consistency across sections.
  * Expanded several guides with practical steps, worked examples, and tighter cross-references to supporting materials.
  * Removed standalone “Reference Files” sections across many guides and relied on inline references plus “Further Reading.”
  * Refreshed front-matter wording and bumped framework versions in multiple documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->