### PR TITLE
Sync marketplace versions to release + automate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,13 +8,13 @@
   },
   "metadata": {
     "description": "50 agent skills for product strategy, UX design, marketing, sales, motivation, conversion optimization, code quality, and systems architecture — based on bestselling books",
-    "version": "1.6.0"
+    "version": "1.4.0"
   },
   "plugins": [
     {
       "name": "product-strategy",
       "description": "Product strategy and innovation frameworks including Jobs to Be Done (Clayton Christensen) for customer discovery and product design, tactical negotiation skills (Chris Voss), willingness-to-pay pricing (Monetizing Innovation), and startup metrics (Lean Analytics)",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "author": {
         "name": "Wondel.ai",
         "url": "https://wondel.ai"
@@ -23,7 +23,23 @@
       "repository": "https://github.com/wondelai/skills",
       "license": "MIT",
       "category": "productivity",
-      "keywords": ["product-strategy", "jobs-to-be-done", "negotiation", "customer-discovery", "innovation", "pricing", "willingness-to-pay", "metrics", "analytics", "omtm", "customer-interviews", "salary-negotiation", "what-to-charge", "north-star-metric", "product-market-fit"],
+      "keywords": [
+        "product-strategy",
+        "jobs-to-be-done",
+        "negotiation",
+        "customer-discovery",
+        "innovation",
+        "pricing",
+        "willingness-to-pay",
+        "metrics",
+        "analytics",
+        "omtm",
+        "customer-interviews",
+        "salary-negotiation",
+        "what-to-charge",
+        "north-star-metric",
+        "product-market-fit"
+      ],
       "source": "./",
       "strict": false,
       "skills": [
@@ -37,7 +53,7 @@
     {
       "name": "ux-design",
       "description": "UX and UI design skills including Refactoring UI, iOS HIG design, usability heuristics, habit-forming product design, behavior design for retention, web typography, award-winning top-design, Steve Jobs-style design reviews, and Don Norman's foundational design principles",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "author": {
         "name": "Wondel.ai",
         "url": "https://wondel.ai"
@@ -46,7 +62,28 @@
       "repository": "https://github.com/wondelai/skills",
       "license": "MIT",
       "category": "design",
-      "keywords": ["ux", "ui", "design", "ios", "hig", "typography", "usability", "refactoring-ui", "hooked", "retention", "behavior-design", "tiny-habits", "steve-jobs", "design-review", "simplicity", "make-it-look-better", "ui-polish", "font-pairing", "microinteractions", "usability-audit"],
+      "keywords": [
+        "ux",
+        "ui",
+        "design",
+        "ios",
+        "hig",
+        "typography",
+        "usability",
+        "refactoring-ui",
+        "hooked",
+        "retention",
+        "behavior-design",
+        "tiny-habits",
+        "steve-jobs",
+        "design-review",
+        "simplicity",
+        "make-it-look-better",
+        "ui-polish",
+        "font-pairing",
+        "microinteractions",
+        "usability-audit"
+      ],
       "source": "./",
       "strict": false,
       "skills": [
@@ -66,7 +103,7 @@
     {
       "name": "marketing-cro",
       "description": "Marketing and conversion optimization skills including CRO methodology, StoryBrand messaging, Scorecard Marketing lead generation, viral marketing (Contagious), and 1-Page Marketing Plan",
-      "version": "1.1.0",
+      "version": "1.4.0",
       "author": {
         "name": "Wondel.ai",
         "url": "https://wondel.ai"
@@ -75,7 +112,20 @@
       "repository": "https://github.com/wondelai/skills",
       "license": "MIT",
       "category": "productivity",
-      "keywords": ["marketing", "cro", "conversion", "storybrand", "copywriting", "lead-generation", "virality", "landing-page", "ab-testing", "quiz-funnel", "go-viral", "homepage-copy"],
+      "keywords": [
+        "marketing",
+        "cro",
+        "conversion",
+        "storybrand",
+        "copywriting",
+        "lead-generation",
+        "virality",
+        "landing-page",
+        "ab-testing",
+        "quiz-funnel",
+        "go-viral",
+        "homepage-copy"
+      ],
       "source": "./",
       "strict": false,
       "skills": [
@@ -89,7 +139,7 @@
     {
       "name": "sales-influence",
       "description": "Sales, persuasion, and messaging skills including Cialdini's influence psychology, Aaron Ross's outbound sales methodology, Heath Brothers' sticky messaging, and Alex Hormozi's offer creation",
-      "version": "1.1.0",
+      "version": "1.4.0",
       "author": {
         "name": "Wondel.ai",
         "url": "https://wondel.ai"
@@ -98,7 +148,20 @@
       "repository": "https://github.com/wondelai/skills",
       "license": "MIT",
       "category": "productivity",
-      "keywords": ["sales", "influence", "persuasion", "outbound", "messaging", "offers", "copywriting", "social-proof", "cold-email", "irresistible-offer", "objection-handling", "pricing"],
+      "keywords": [
+        "sales",
+        "influence",
+        "persuasion",
+        "outbound",
+        "messaging",
+        "offers",
+        "copywriting",
+        "social-proof",
+        "cold-email",
+        "irresistible-offer",
+        "objection-handling",
+        "pricing"
+      ],
       "source": "./",
       "strict": false,
       "skills": [
@@ -111,7 +174,7 @@
     {
       "name": "product-innovation",
       "description": "Product innovation and validation frameworks including Lean Startup methodology, Google Ventures Design Sprint, and Don Norman's design principles",
-      "version": "1.1.0",
+      "version": "1.4.0",
       "author": {
         "name": "Wondel.ai",
         "url": "https://wondel.ai"
@@ -120,7 +183,18 @@
       "repository": "https://github.com/wondelai/skills",
       "license": "MIT",
       "category": "productivity",
-      "keywords": ["lean-startup", "mvp", "design-sprint", "validation", "innovation", "prototyping", "pivot-or-persevere", "validate-an-idea", "product-discovery", "empowered-teams"],
+      "keywords": [
+        "lean-startup",
+        "mvp",
+        "design-sprint",
+        "validation",
+        "innovation",
+        "prototyping",
+        "pivot-or-persevere",
+        "validate-an-idea",
+        "product-discovery",
+        "empowered-teams"
+      ],
       "source": "./",
       "strict": false,
       "skills": [
@@ -135,7 +209,7 @@
     {
       "name": "strategy-growth",
       "description": "Business strategy and growth frameworks including Crossing the Chasm tech adoption, Blue Ocean Strategy value innovation, EOS business operating system, Obviously Awesome positioning, Good Strategy Bad Strategy kernels, and Cold Start Problem network effects",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "author": {
         "name": "Wondel.ai",
         "url": "https://wondel.ai"
@@ -144,7 +218,23 @@
       "repository": "https://github.com/wondelai/skills",
       "license": "MIT",
       "category": "productivity",
-      "keywords": ["strategy", "growth", "positioning", "blue-ocean", "eos", "go-to-market", "traction", "strategy-kernel", "network-effects", "marketplace", "cold-start", "stop-competing-on-price", "crossing-the-chasm", "category-creation", "annual-planning"],
+      "keywords": [
+        "strategy",
+        "growth",
+        "positioning",
+        "blue-ocean",
+        "eos",
+        "go-to-market",
+        "traction",
+        "strategy-kernel",
+        "network-effects",
+        "marketplace",
+        "cold-start",
+        "stop-competing-on-price",
+        "crossing-the-chasm",
+        "category-creation",
+        "annual-planning"
+      ],
       "source": "./",
       "strict": false,
       "skills": [
@@ -159,7 +249,7 @@
     {
       "name": "team-motivation",
       "description": "Team motivation and management skills including Daniel Pink's Autonomy, Mastery, Purpose (AMP) principles and Andy Grove's High Output Management (leverage, one-on-ones, OKRs, task-relevant maturity)",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "author": {
         "name": "Wondel.ai",
         "url": "https://wondel.ai"
@@ -168,7 +258,22 @@
       "repository": "https://github.com/wondelai/skills",
       "license": "MIT",
       "category": "productivity",
-      "keywords": ["motivation", "autonomy", "mastery", "purpose", "engagement", "team-management", "management", "one-on-ones", "okrs", "leverage", "new-manager", "team-disengaged", "performance-review", "delegation"],
+      "keywords": [
+        "motivation",
+        "autonomy",
+        "mastery",
+        "purpose",
+        "engagement",
+        "team-management",
+        "management",
+        "one-on-ones",
+        "okrs",
+        "leverage",
+        "new-manager",
+        "team-disengaged",
+        "performance-review",
+        "delegation"
+      ],
       "source": "./",
       "strict": false,
       "skills": [
@@ -179,7 +284,7 @@
     {
       "name": "code-craftsmanship",
       "description": "Code quality and software design skills including Clean Code (Robert C. Martin), Refactoring patterns (Martin Fowler), A Philosophy of Software Design (John Ousterhout), The Pragmatic Programmer (Hunt & Thomas), Domain-Driven Design (Eric Evans), and Working Effectively with Legacy Code (Michael Feathers)",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "author": {
         "name": "Wondel.ai",
         "url": "https://wondel.ai"
@@ -188,7 +293,23 @@
       "repository": "https://github.com/wondelai/skills",
       "license": "MIT",
       "category": "productivity",
-      "keywords": ["clean-code", "refactoring", "code-quality", "software-design", "ddd", "domain-driven-design", "pragmatic", "legacy-code", "characterization-tests", "seams", "code-review", "code-smells", "technical-debt", "over-engineered", "untested-code"],
+      "keywords": [
+        "clean-code",
+        "refactoring",
+        "code-quality",
+        "software-design",
+        "ddd",
+        "domain-driven-design",
+        "pragmatic",
+        "legacy-code",
+        "characterization-tests",
+        "seams",
+        "code-review",
+        "code-smells",
+        "technical-debt",
+        "over-engineered",
+        "untested-code"
+      ],
       "source": "./",
       "strict": false,
       "skills": [
@@ -203,7 +324,7 @@
     {
       "name": "systems-architecture",
       "description": "Systems architecture and distributed systems skills including Designing Data-Intensive Applications (Martin Kleppmann), System Design Interview (Alex Xu), Clean Architecture (Robert C. Martin), Release It! (Michael Nygard), High Performance Browser Networking (Ilya Grigorik), and Team Topologies (Skelton & Pais)",
-      "version": "1.2.0",
+      "version": "1.4.0",
       "author": {
         "name": "Wondel.ai",
         "url": "https://wondel.ai"
@@ -212,7 +333,24 @@
       "repository": "https://github.com/wondelai/skills",
       "license": "MIT",
       "category": "productivity",
-      "keywords": ["system-design", "architecture", "distributed-systems", "scalability", "resilience", "performance", "clean-architecture", "team-topologies", "conways-law", "platform-teams", "org-design", "system-design-interview", "database-choice", "circuit-breaker", "core-web-vitals", "sql-or-nosql"],
+      "keywords": [
+        "system-design",
+        "architecture",
+        "distributed-systems",
+        "scalability",
+        "resilience",
+        "performance",
+        "clean-architecture",
+        "team-topologies",
+        "conways-law",
+        "platform-teams",
+        "org-design",
+        "system-design-interview",
+        "database-choice",
+        "circuit-breaker",
+        "core-web-vitals",
+        "sql-or-nosql"
+      ],
       "source": "./",
       "strict": false,
       "skills": [

--- a/.github/workflows/sync-marketplace-version.yml
+++ b/.github/workflows/sync-marketplace-version.yml
@@ -1,0 +1,57 @@
+name: Sync marketplace versions
+
+# Keeps .claude-plugin/marketplace.json versions equal to the latest GitHub
+# release, so plugin consumers (/plugin install <collection>@wondelai-skills)
+# are offered refreshed skills after every release. Runs automatically on each
+# published release; can also be triggered manually with an explicit version.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to sync, e.g. 1.4.0 (defaults to the latest release/tag)"
+        required: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: sync-marketplace-version
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: ver
+        run: |
+          v="${{ github.event.release.tag_name }}"
+          [ -z "$v" ] && v="${{ github.event.inputs.version }}"
+          [ -z "$v" ] && v="$(git describe --tags --abbrev=0)"
+          v="${v#v}"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $v"
+
+      - name: Sync marketplace.json
+        run: scripts/sync-marketplace-versions.sh "${{ steps.ver.outputs.version }}"
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet -- .claude-plugin/marketplace.json; then
+            echo "marketplace.json already in sync — nothing to do"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/marketplace.json
+          git commit -m "chore: sync marketplace.json versions to ${{ steps.ver.outputs.version }} [skip ci]"
+          git push origin main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ The YAML frontmatter `description` field is critical for skill discovery - it sh
    - Add row to "Available Skills" table
    - Add "Skill Details" section (description, About the author, Use when, Example prompts)
    - Add to "Copyright & Disclaimer" section
-5. Add the skill to `.claude-plugin/marketplace.json` under the appropriate plugin collection
+5. Add the skill's path to `.claude-plugin/marketplace.json` under the appropriate plugin collection (add the `./skill-name` entry only — do **not** hand-pick a version; see Versioning Policy)
 
 ## Installation
 
@@ -149,6 +149,10 @@ metadata:
   author: wondelai
   version: "1.1.0"
 ```
+
+### Marketplace versions (automated)
+
+The versions in `.claude-plugin/marketplace.json` (top-level `metadata.version` and every `plugins[].version`) are **not** hand-edited. They are auto-synced to the latest GitHub release by `.github/workflows/sync-marketplace-version.yml`, which runs `scripts/sync-marketplace-versions.sh` on each published release and commits the result to `main`. To ship: bump the affected skills' `SKILL.md` versions, merge, then publish a `vX.Y.Z` GitHub release — the workflow sets all marketplace versions to `X.Y.Z`. To sync without a release, run `scripts/sync-marketplace-versions.sh X.Y.Z` locally.
 
 ## Commit Policy
 

--- a/scripts/sync-marketplace-versions.sh
+++ b/scripts/sync-marketplace-versions.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# sync-marketplace-versions.sh — align .claude-plugin/marketplace.json versions
+# to a single release version (the source of truth for plugin consumers).
+#
+# Sets the top-level metadata.version AND every plugins[].version to VERSION,
+# so that `/plugin install <collection>@wondelai-skills` users are offered the
+# refreshed skills after each release.
+#
+# Usage:
+#   scripts/sync-marketplace-versions.sh [VERSION]
+#
+#   VERSION  e.g. 1.4.0 or v1.4.0 (the leading "v" is stripped).
+#            Defaults to the latest git tag (`git describe --tags --abbrev=0`).
+#
+# Idempotent: re-running with the same version is a no-op. Run automatically by
+# .github/workflows/sync-marketplace-version.yml on each published release.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+MP=".claude-plugin/marketplace.json"
+
+[[ -f "$MP" ]] || { echo "Error: $MP not found" >&2; exit 1; }
+
+ver="${1:-}"
+[[ -z "$ver" ]] && ver="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+ver="${ver#v}"
+
+if [[ ! "$ver" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Error: need a semver version. Pass X.Y.Z, or create a vX.Y.Z tag. Got: '${ver:-<empty>}'" >&2
+  exit 1
+fi
+
+tmp="$(mktemp)"
+jq --arg v "$ver" '
+  .metadata.version = $v
+  | .plugins = (.plugins | map(.version = $v))
+' "$MP" > "$tmp" && mv "$tmp" "$MP"
+
+echo "Synced $MP -> version $ver (metadata.version + $(jq '.plugins | length' "$MP") plugin collections)"


### PR DESCRIPTION
## What

Plugin-collection versions in `marketplace.json` lagged the skill content (1.1.0/1.2.0), so `/plugin install <collection>@wondelai-skills` users weren't offered the **v1.4.0** refresh. This aligns them to the GitHub release and keeps them synced automatically from now on.

## Changes
- **Versions → 1.4.0**: top-level `metadata.version` + all 9 plugin collections now equal the `v1.4.0` release. Collections bumped up from 1.1.0/1.2.0; top-level realigned from an ad-hoc `1.6.0` down to track the release tag (flagged — happy to keep 1.6.0 if you'd rather not realign).
- **`scripts/sync-marketplace-versions.sh`** — sets every marketplace version to a given release/tag (defaults to latest tag); idempotent; reusable manually.
- **`.github/workflows/sync-marketplace-version.yml`** — on each **published release** (and manual `workflow_dispatch`), runs the script with the release tag and commits the result to `main`. `main` is unprotected, so the bot can push directly.
- **`CLAUDE.md`** — documents that marketplace versions are auto-synced and must not be hand-edited.

## Going forward
Release flow becomes: bump skills' `SKILL.md` versions → merge → publish a `vX.Y.Z` GitHub release → the workflow sets all marketplace versions to `X.Y.Z`. No more manual marketplace version edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ygbNRWuZjaizDpcLEQ6jj
