### PR TITLE
docs: broaden agent-compatibility tagline (Codex, OpenClaw, Hermes Agent)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,6 +1,6 @@
 # Wondel.ai Skills Repository
 
-You are working in a collection of agent skills for Claude Code and agentskills.io-compatible agents.
+You are working in a collection of agent skills for Claude Code, Codex, OpenClaw, Hermes Agent and other agentskills.io-compatible agents.
 
 ## Repository Purpose
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Agent Skills Repository Instructions
 
-This repository contains agent skills for Claude Code and agentskills.io-compatible agents.
+This repository contains agent skills for Claude Code, Codex, OpenClaw, Hermes Agent and other agentskills.io-compatible agents.
 
 ## Key Requirements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Purpose
 
-This is a collection of 50 agent skills for Claude Code and agentskills.io-compatible agents. Skills provide specialized domain knowledge and frameworks for specific use cases (UX design, marketing, product strategy, sales, operations, positioning, virality, code quality, systems architecture, etc.).
+This is a collection of 50 agent skills for Claude Code, Codex, OpenClaw, Hermes Agent and other agentskills.io-compatible agents. Skills provide specialized domain knowledge and frameworks for specific use cases (UX design, marketing, product strategy, sales, operations, positioning, virality, code quality, systems architecture, etc.).
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wondel.ai Skills
 
-Agent skills for Claude Code and agentskills.io-compatible agents. Browse all skills at [skills.wondel.ai](https://skills.wondel.ai/).
+Agent skills for Claude Code, Codex, OpenClaw, Hermes Agent and other agentskills.io-compatible agents. Browse all skills at [skills.wondel.ai](https://skills.wondel.ai/).
 
 ## Installation
 


### PR DESCRIPTION
Names Codex, OpenClaw, and Hermes Agent explicitly in the agent-compatibility tagline (was "Claude Code and agentskills.io-compatible agents"), across README, CLAUDE.md, .cursorrules, and .github/copilot-instructions.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ygbNRWuZjaizDpcLEQ6jj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded repository and project descriptions to explicitly mention additional compatible agent platforms, including Codex, OpenClaw, and Hermes Agent.
  * Updated introductory wording across key docs to better reflect broader client compatibility while keeping existing compatibility references intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->