### PR TITLE
docs: expand Claude family + add Cursor to compatibility tagline

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,6 +1,6 @@
 # Wondel.ai Skills Repository
 
-You are working in a collection of agent skills for Claude Code, Codex, OpenClaw, Hermes Agent and other agentskills.io-compatible agents.
+You are working in a collection of agent skills for Claude, Claude Code, Claude Cowork, Codex, Cursor, OpenClaw, Hermes Agent and other agentskills.io-compatible agents.
 
 ## Repository Purpose
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Agent Skills Repository Instructions
 
-This repository contains agent skills for Claude Code, Codex, OpenClaw, Hermes Agent and other agentskills.io-compatible agents.
+This repository contains agent skills for Claude, Claude Code, Claude Cowork, Codex, Cursor, OpenClaw, Hermes Agent and other agentskills.io-compatible agents.
 
 ## Key Requirements
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Purpose
 
-This is a collection of 50 agent skills for Claude Code, Codex, OpenClaw, Hermes Agent and other agentskills.io-compatible agents. Skills provide specialized domain knowledge and frameworks for specific use cases (UX design, marketing, product strategy, sales, operations, positioning, virality, code quality, systems architecture, etc.).
+This is a collection of 50 agent skills for Claude, Claude Code, Claude Cowork, Codex, Cursor, OpenClaw, Hermes Agent and other agentskills.io-compatible agents. Skills provide specialized domain knowledge and frameworks for specific use cases (UX design, marketing, product strategy, sales, operations, positioning, virality, code quality, systems architecture, etc.).
 
 ## Repository Structure
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wondel.ai Skills
 
-Agent skills for Claude Code, Codex, OpenClaw, Hermes Agent and other agentskills.io-compatible agents. Browse all skills at [skills.wondel.ai](https://skills.wondel.ai/).
+Agent skills for Claude, Claude Code, Claude Cowork, Codex, Cursor, OpenClaw, Hermes Agent and other agentskills.io-compatible agents. Browse all skills at [skills.wondel.ai](https://skills.wondel.ai/).
 
 ## Installation
 


### PR DESCRIPTION
Tagline is now "Agent skills for **Claude, Claude Code, Claude Cowork, Codex, Cursor, OpenClaw, Hermes Agent** and other agentskills.io-compatible agents" across README, CLAUDE.md, .cursorrules, and .github/copilot-instructions.md. Install headings/commands that mention "Claude Code" are intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ygbNRWuZjaizDpcLEQ6jj

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository and skill descriptions to list additional supported AI agent platforms, including Cursor and other Claude-related products.
  * Broadened the visible platform list in multiple guidance files so the supported ecosystem is clearer to readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->