### PR TITLE
docs: add "Work With Us" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,6 +1316,18 @@ Developer Toolkit is a comprehensive learning platform for mastering AI-assisted
 
 ---
 
+## Work With Us
+
+These 50 skills are the open-source tip of what we do. **[Wondel.ai](https://skills.wondel.ai/work-with-us/)** builds custom Claude skills, agents, and MCP integrations — shipped to production, not demoed.
+
+- **Skill sprints** — a focused, eval-backed skill scoped and shipped fast
+- **Custom builds** — production AI systems combining skills, agents, and MCP integrations
+- **Skills library** — an ongoing, maintained library of skills for your team
+
+Evals are the deliverable, not an afterthought — shipped to production, or you don't pay the final milestone. **[Book a quick call →](https://skills.wondel.ai/work-with-us/)**
+
+---
+
 ## Copyright & Disclaimer
 
 The methodologies and frameworks referenced in these skills are the intellectual property of their respective authors and publishers. All copyrights belong to:


### PR DESCRIPTION
## What

Adds a **Work With Us** section to `README.md`, linking to https://skills.wondel.ai/work-with-us/.

## Where

Placed between the existing *Learn More: The Skills Ecosystem* section and the *Copyright & Disclaimer* footer — a natural call-to-action slot above the legal boilerplate.

## Details

- Frames the 50 open-source skills as the tip of Wondel.ai's custom work (skills, agents, MCP integrations).
- Lists the three service tiers — **skill sprints**, **custom builds**, **skills library** — described qualitatively rather than with hardcoded prices, so the linked page stays the source of truth.
- Ends with a "Book a quick call →" CTA to the same URL.

Docs-only change; no skill `SKILL.md`/`references` touched, so no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWKbscRFaitbTd912vV5VE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Work With Us” section to the README.
  * Expanded the overview of available services and highlighted several offering types.
  * Included a call-to-action link for evals and payments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->