### PR TITLE
jobs-to-be-done: expand diagnostics.md with inline checklists and interview questions

### DIFF
--- a/jobs-to-be-done/references/diagnostics.md
+++ b/jobs-to-be-done/references/diagnostics.md
@@ -1,6 +1,27 @@
 # Product Diagnostics Through JTBD Lens
 
-This file is the deep diagnostic layer behind SKILL.md. Run the **Quick Diagnostic** table in SKILL.md first for the seven pass/fail readiness checks; come here when a symptom needs a probable cause, when you need JTBD metrics, or when you are running a churn analysis.
+## Checklist: Do You Know Your Product's Job?
+
+### Level 1: Basic Understanding
+
+- [ ] You can describe the job in one sentence without using the product name
+- [ ] You know the circumstances in which the job arises
+- [ ] You know what customer did BEFORE using your product
+- [ ] You understand the functional, emotional, AND social dimensions
+
+### Level 2: Deep Understanding
+
+- [ ] You know what you really compete with (not just "direct competitors")
+- [ ] You understand push/pull and habit/anxiety forces for your customer
+- [ ] You can distinguish Big Hire from Little Hire
+- [ ] You know why customers "fire" your product
+
+### Level 3: Organizational Implementation
+
+- [ ] Product decisions are filtered through the job lens
+- [ ] Metrics measure job completion, not just usage
+- [ ] Roadmap is oriented toward better job execution
+- [ ] Team can articulate the customer's job
 
 ## Red Flags - Signs You Don't Know the Job
 
@@ -22,7 +43,26 @@ This file is the deep diagnostic layer behind SKILL.md. Run the **Quick Diagnost
 | They buy but don't use | Little Hire lost | Redesign the moment of use |
 | They use but churn | Job changed or better "employee" appeared | Investigate "firing" reasons |
 
-For the full timeline-interview question set (first-thought -> search -> purchase -> usage), see SKILL.md section 5; for the structured churn ("firing") interview, see the Churn Interview Framework table below.
+### "Firing" Interview (Churn Interview)
+
+Questions for customers who left:
+
+1. "What did you do before us? Why did you come to us?"
+2. "What changed that made you start looking for alternatives?"
+3. "What ultimately convinced you to leave?"
+4. "What do you do now instead of us? Does it do the job better?"
+5. "If we could change one thing, what would it be?"
+
+### "Hiring" Interview (New Customer Interview)
+
+Questions for new customers (within 2 weeks):
+
+1. "When did you first think about looking for a solution?"
+2. "What was the trigger - what was happening then?"
+3. "What alternatives did you look for? What disqualified them?"
+4. "What ultimately convinced you to choose us?"
+5. "What were you afraid of before buying?"
+6. "Is the product doing what you expected?"
 
 ## JTBD Metrics
 


### PR DESCRIPTION
Fixes #20

## What this changes

`references/diagnostics.md` currently defers to SKILL.md for its core content. This PR embeds that content directly.

### Changes

**Line 3** — Replaces the meta-description with `## Checklist: Do You Know Your Product's Job?`

**Added: 3-level JTBD Readiness Checklist**
- Level 1: Basic Understanding (4 checks)
- Level 2: Deep Understanding (4 checks)
- Level 3: Organizational Implementation (4 checks)

**Line 25** — Replaces the "see SKILL.md section 5" pointer with actual inline content:

**Added: "Firing" Interview (Churn Interview)** — 5 questions for customers who left

**Added: "Hiring" Interview (New Customer Interview)** — 6 questions for customers within their first 2 weeks

## Why

Reference files are loaded at runtime. Content that says "go look in SKILL.md" defeats the purpose of having a dedicated reference file. These additions were developed in production use and fill the gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a structured JTBD readiness checklist covering basic understanding, deep understanding, and organizational implementation.
  * Added detailed interview question sets for understanding customer churn and onboarding new customers.
  * Expanded guidance on job articulation, competitive analysis, alternatives, expectations, and improvement opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->